### PR TITLE
Add npm test as an alias for `npm run shim:test`

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "url": "git+https://github.com/Agoric/realms-shim.git"
   },
   "scripts": {
+    "test": "npm run shim:test",
     "shim:lint": "eslint ./src ./test ./examples",
     "shim:prettier": "prettier --config ./.prettierrc --write ./src/**/**/*.js ./test/**/**/*.js ./examples/**/**/*.js",
     "shim:test": "tape -r esm ./test/**/**/*.js",


### PR DESCRIPTION
This PR enables `npm test` as an alias for `npm run shim:test`