### PR TITLE
Reject questionable inputs. Make stable globals fast. 80 columns.

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,5 @@
 {
-  "printWidth": 100,
+  "printWidth": 80,
   "parser": "flow",
   "useTabs": false,
   "tabWidth": 2,

--- a/examples/simple.js
+++ b/examples/simple.js
@@ -41,7 +41,8 @@ document.getElementById('run').addEventListener('click', () => {
     result = `Error: ${e}`;
   }
   try {
-    output = typeof result === 'function' ? result.toString() : JSON.stringify(result);
+    output =
+      typeof result === 'function' ? result.toString() : JSON.stringify(result);
   } catch (e) {
     output = `Error trying to serialize the result: ${e}\nOriginal Object: ${result}`;
   }

--- a/src/commons.js
+++ b/src/commons.js
@@ -11,7 +11,7 @@ export const {
   create,
   freeze,
   defineProperties, // Object.defineProperty is allowed to fail
-                    // silentlty, use Object.defineProperties instead.
+  // silentlty, use Object.defineProperties instead.
   getOwnPropertyDescriptor,
   getOwnPropertyDescriptors,
   getOwnPropertyNames,
@@ -22,7 +22,7 @@ export const {
 export const {
   apply,
   ownKeys // Reflect.ownKeys includes Symbols and unenumerables,
-          // unlike Object.keys()
+  // unlike Object.keys()
 } = Reflect;
 
 /**
@@ -45,8 +45,9 @@ const uncurryThis = fn => (thisArg, ...args) => apply(fn, thisArg, args);
 
 // We also capture these for security: changes to Array.prototype after the
 // Realm shim runs shouldn't affect subsequent Realm operations.
-export const
-  objectHasOwnProperty = uncurryThis(Object.prototype.hasOwnProperty),
+export const objectHasOwnProperty = uncurryThis(
+    Object.prototype.hasOwnProperty
+  ),
   arrayForEach = uncurryThis(Array.prototype.forEach),
   arrayFilter = uncurryThis(Array.prototype.filter),
   arrayPush = uncurryThis(Array.prototype.push),

--- a/src/commons.js
+++ b/src/commons.js
@@ -10,7 +10,8 @@ export const {
   assign,
   create,
   freeze,
-  defineProperties, // Object.defineProperty is allowed to fail silentlty, use Object.defineProperties instead.
+  defineProperties, // Object.defineProperty is allowed to fail
+                    // silentlty, use Object.defineProperties instead.
   getOwnPropertyDescriptor,
   getOwnPropertyDescriptors,
   getOwnPropertyNames,
@@ -20,18 +21,22 @@ export const {
 
 export const {
   apply,
-  ownKeys // Reflect.ownKeys includes Symbols and unenumerables, unlike Object.keys()
+  ownKeys // Reflect.ownKeys includes Symbols and unenumerables,
+          // unlike Object.keys()
 } = Reflect;
 
 /**
- * uncurryThis()
- * See http://wiki.ecmascript.org/doku.php?id=conventions:safe_meta_programming
- * which only lives at http://web.archive.org/web/20160805225710/http://wiki.ecmascript.org/doku.php?id=conventions:safe_meta_programming
+ * uncurryThis() See
+ * http://wiki.ecmascript.org/doku.php?id=conventions:safe_meta_programming
+ * which only lives at
+ * http://web.archive.org/web/20160805225710/http://wiki.ecmascript.org/doku.php?id=conventions:safe_meta_programming
  *
  * Performance:
  * 1. The native call is about 10x faster on FF than chrome
- * 2. The version using Function.bind() is about 100x slower on FF, equal on chrome, 2x slower on Safari
- * 3. The version using a spread and Reflect.apply() is about 10x slower on FF, equal on chrome, 2x slower on Safari
+ * 2. The version using Function.bind() is about 100x slower on FF,
+ *    equal on chrome, 2x slower on Safari
+ * 3. The version using a spread and Reflect.apply() is about 10x
+ *    slower on FF, equal on chrome, 2x slower on Safari
  *
  * const bind = Function.prototype.bind;
  * const uncurryThis = bind.bind(bind.call);
@@ -40,7 +45,8 @@ const uncurryThis = fn => (thisArg, ...args) => apply(fn, thisArg, args);
 
 // We also capture these for security: changes to Array.prototype after the
 // Realm shim runs shouldn't affect subsequent Realm operations.
-export const objectHasOwnProperty = uncurryThis(Object.prototype.hasOwnProperty),
+export const
+  objectHasOwnProperty = uncurryThis(Object.prototype.hasOwnProperty),
   arrayForEach = uncurryThis(Array.prototype.forEach),
   arrayFilter = uncurryThis(Array.prototype.filter),
   arrayPush = uncurryThis(Array.prototype.push),

--- a/src/evaluators.js
+++ b/src/evaluators.js
@@ -142,6 +142,10 @@ export function createSafeEvaluatorFactory(unsafeRec, safeGlobal) {
     // this to a plain arrow function. Now that we have safeEval, use it.
     defineProperties(safeEval, {
       toString: {
+        // We break up the following literal string so that an
+        // apparent direct eval syntax does not appear in this
+        // file. Thus, we avoid rejection by the overly eager
+        // rejectDangerousSources.
         value: safeEval("() => 'function eval' + '() { [shim code] }'"),
         writable: false,
         enumerable: false,

--- a/src/evaluators.js
+++ b/src/evaluators.js
@@ -41,7 +41,8 @@ function createScopedEvaluatorFactory(unsafeRec, constants) {
   // 2: 'optimizer' catches common variable names for speed
   // 3: The inner strict function is effectively passed two parameters:
   //    a) its arguments[0] is the source to be directly evaluated.
-  //    b) its 'this' is the this binding seen by the code being directly evaluated.
+  //    b) its 'this' is the this binding seen by the code being
+  //       directly evaluated.
 
   // everything in the 'optimizer' string is looked up in the proxy
   // (including an 'arguments[0]', which points at the Proxy). 'function' is
@@ -195,7 +196,8 @@ export function createFunctionEvaluator(unsafeRec, safeEval) {
       // character - it may make the combined function expression
       // compile. We avoid this problem by checking for this early on.
 
-      // note: v8 throws just like this does, but chrome accepts e.g. 'a = new Date()'
+      // note: v8 throws just like this does, but chrome accepts
+      // e.g. 'a = new Date()'
       throw new unsafeGlobal.SyntaxError(
         'shim limitation: Function arg string contains parenthesis'
       );
@@ -220,16 +222,19 @@ export function createFunctionEvaluator(unsafeRec, safeEval) {
   // with instance checks in any compartment of the same root realm.
   setPrototypeOf(safeFunction, unsafeFunction.prototype);
 
-  assert(getPrototypeOf(safeFunction).constructor !== Function, 'hide Function');
-  assert(getPrototypeOf(safeFunction).constructor !== unsafeFunction, 'hide unsafeFunction');
+  assert(getPrototypeOf(safeFunction).constructor !== Function,
+         'hide Function');
+  assert(getPrototypeOf(safeFunction).constructor !== unsafeFunction,
+         'hide unsafeFunction');
 
   defineProperties(safeFunction, {
     // Ensure that any function created in any compartment in a root realm is an
     // instance of Function in any compartment of the same root ralm.
     prototype: { value: unsafeFunction.prototype },
 
-    // Provide a custom output without overwriting the Function.prototype.toString
-    // which is called by some third-party libraries.
+    // Provide a custom output without overwriting the
+    // Function.prototype.toString which is called by some third-party
+    // libraries.
     toString: {
       value: safeEval("() => 'function Function() { [shim code] }'"),
       writable: false,

--- a/src/evaluators.js
+++ b/src/evaluators.js
@@ -71,9 +71,10 @@ function createScopedEvaluatorFactory(unsafeRec, constants) {
 export function createSafeEvaluatorFactory(unsafeRec, safeGlobal) {
   const { unsafeFunction } = unsafeRec;
 
-  const scopeHandler = createScopeHandler(unsafeRec);
-  const optimizableGlobals = getOptimizableGlobals(safeGlobal);
-  const scopedEvaluatorFactory = createScopedEvaluatorFactory(unsafeRec, optimizableGlobals);
+  const scopeHandler = createScopeHandler(unsafeRec, safeGlobal);
+  const constants = getOptimizableGlobals(safeGlobal);
+  const scopedEvaluatorFactory =
+        createScopedEvaluatorFactory(unsafeRec, constants);
 
   function factory(endowments = {}) {
     // todo (shim limitation): scan endowments, throw error if endowment

--- a/src/evaluators.js
+++ b/src/evaluators.js
@@ -73,8 +73,10 @@ export function createSafeEvaluatorFactory(unsafeRec, safeGlobal) {
 
   const scopeHandler = createScopeHandler(unsafeRec, safeGlobal);
   const constants = getOptimizableGlobals(safeGlobal);
-  const scopedEvaluatorFactory =
-        createScopedEvaluatorFactory(unsafeRec, constants);
+  const scopedEvaluatorFactory = createScopedEvaluatorFactory(
+    unsafeRec,
+    constants
+  );
 
   function factory(endowments = {}) {
     // todo (shim limitation): scan endowments, throw error if endowment
@@ -85,9 +87,14 @@ export function createSafeEvaluatorFactory(unsafeRec, safeGlobal) {
     // writeable-vs-nonwritable == let-vs-const, but there's no
     // global-lexical-scope equivalent of an accessor, outside what we can
     // explain/spec
-    const scopeTarget = create(safeGlobal, getOwnPropertyDescriptors(endowments));
+    const scopeTarget = create(
+      safeGlobal,
+      getOwnPropertyDescriptors(endowments)
+    );
     const scopeProxy = new Proxy(scopeTarget, scopeHandler);
-    const scopedEvaluator = apply(scopedEvaluatorFactory, safeGlobal, [scopeProxy]);
+    const scopedEvaluator = apply(scopedEvaluatorFactory, safeGlobal, [
+      scopeProxy
+    ]);
 
     // We use the the concise method syntax to create an eval without a
     // [[Construct]] behavior (such that the invocation "new eval()" throws
@@ -126,7 +133,10 @@ export function createSafeEvaluatorFactory(unsafeRec, safeGlobal) {
     setPrototypeOf(safeEval, unsafeFunction.prototype);
 
     assert(getPrototypeOf(safeEval).constructor !== Function, 'hide Function');
-    assert(getPrototypeOf(safeEval).constructor !== unsafeFunction, 'hide unsafeFunction');
+    assert(
+      getPrototypeOf(safeEval).constructor !== unsafeFunction,
+      'hide unsafeFunction'
+    );
 
     // note: be careful to not leak our primal Function.prototype by setting
     // this to a plain arrow function. Now that we have safeEval, use it.
@@ -223,10 +233,14 @@ export function createFunctionEvaluator(unsafeRec, safeEval) {
   // with instance checks in any compartment of the same root realm.
   setPrototypeOf(safeFunction, unsafeFunction.prototype);
 
-  assert(getPrototypeOf(safeFunction).constructor !== Function,
-         'hide Function');
-  assert(getPrototypeOf(safeFunction).constructor !== unsafeFunction,
-         'hide unsafeFunction');
+  assert(
+    getPrototypeOf(safeFunction).constructor !== Function,
+    'hide Function'
+  );
+  assert(
+    getPrototypeOf(safeFunction).constructor !== unsafeFunction,
+    'hide unsafeFunction'
+  );
 
   defineProperties(safeFunction, {
     // Ensure that any function created in any compartment in a root realm is an

--- a/src/evaluators.js
+++ b/src/evaluators.js
@@ -15,7 +15,7 @@ import {
 } from './commons';
 import { getOptimizableGlobals } from './optimizer';
 import { createScopeHandler } from './scopeHandler';
-import { rejectImportExpressions } from './sourceParser';
+import { rejectDangerousSources } from './sourceParser';
 import { assert, throwTantrum } from './utilities';
 
 function buildOptimizer(constants) {
@@ -95,7 +95,7 @@ export function createSafeEvaluatorFactory(unsafeRec, safeGlobal) {
     const safeEval = {
       eval(src) {
         src = `${src}`;
-        rejectImportExpressions(src);
+        rejectDangerousSources(src);
         scopeHandler.allowUnsafeEvaluatorOnce();
         let err;
         try {
@@ -131,7 +131,7 @@ export function createSafeEvaluatorFactory(unsafeRec, safeGlobal) {
     // this to a plain arrow function. Now that we have safeEval, use it.
     defineProperties(safeEval, {
       toString: {
-        value: safeEval("() => 'function eval() { [shim code] }'"),
+        value: safeEval("() => 'function eval' + '() { [shim code] }'"),
         writable: false,
         enumerable: false,
         configurable: true

--- a/src/optimizer.js
+++ b/src/optimizer.js
@@ -104,7 +104,9 @@ export function getOptimizableGlobals(safeGlobal) {
   const constants = arrayFilter(getOwnPropertyNames(descs), name => {
     // Ensure we have a valid identifier. We use regexpTest rather than
     // /../.test() to guard against the case where RegExp has been poisoned.
-    if (name === 'eval' || keywords.has(name) || !regexpTest(identifierPattern, name)) {
+    if (name === 'eval' ||
+        keywords.has(name) ||
+        !regexpTest(identifierPattern, name)) {
       return false;
     }
 

--- a/src/optimizer.js
+++ b/src/optimizer.js
@@ -104,9 +104,11 @@ export function getOptimizableGlobals(safeGlobal) {
   const constants = arrayFilter(getOwnPropertyNames(descs), name => {
     // Ensure we have a valid identifier. We use regexpTest rather than
     // /../.test() to guard against the case where RegExp has been poisoned.
-    if (name === 'eval' ||
-        keywords.has(name) ||
-        !regexpTest(identifierPattern, name)) {
+    if (
+      name === 'eval' ||
+      keywords.has(name) ||
+      !regexpTest(identifierPattern, name)
+    ) {
       return false;
     }
 

--- a/src/realm.js
+++ b/src/realm.js
@@ -26,7 +26,10 @@ function registerRealmRecForRealmInstance(realm, realmRec) {
   // Detect non-objects.
   assert(Object(realm) === realm, 'bad object, not a Realm instance');
   // Attempt to change an existing realmRec on a realm instance. Should not proceed.
-  assert(!RealmRecForRealmInstance.has(realm), 'Realm instance already has a record');
+  assert(
+    !RealmRecForRealmInstance.has(realm),
+    'Realm instance already has a record'
+  );
 
   RealmRecForRealmInstance.set(realm, realmRec);
 }
@@ -52,11 +55,14 @@ function createRealmRec(unsafeRec) {
 
   const safeGlobal = create(unsafeGlobal.Object.prototype, sharedGlobalDescs);
 
-  const safeEvaluatorFactory =
-        createSafeEvaluatorFactory(unsafeRec, safeGlobal);
+  const safeEvaluatorFactory = createSafeEvaluatorFactory(
+    unsafeRec,
+    safeGlobal
+  );
   const safeEval = createSafeEvaluator(safeEvaluatorFactory);
-  const safeEvalWhichTakesEndowments =
-        createSafeEvaluatorWhichTakesEndowments(safeEvaluatorFactory);
+  const safeEvalWhichTakesEndowments = createSafeEvaluatorWhichTakesEndowments(
+    safeEvaluatorFactory
+  );
   const safeFunction = createFunctionEvaluator(unsafeRec, safeEval);
 
   setDefaultBindings(safeGlobal, safeEval, safeFunction);

--- a/src/realm.js
+++ b/src/realm.js
@@ -32,9 +32,7 @@ function registerRealmRecForRealmInstance(realm, realmRec) {
 }
 
 // Initialize the global variables for the new Realm.
-function setDefaultBindings(sharedGlobalDescs, safeGlobal, safeEval, safeFunction) {
-  defineProperties(safeGlobal, sharedGlobalDescs);
-
+function setDefaultBindings(safeGlobal, safeEval, safeFunction) {
   defineProperties(safeGlobal, {
     eval: {
       value: safeEval,
@@ -52,14 +50,16 @@ function setDefaultBindings(sharedGlobalDescs, safeGlobal, safeEval, safeFunctio
 function createRealmRec(unsafeRec) {
   const { sharedGlobalDescs, unsafeGlobal } = unsafeRec;
 
-  const safeGlobal = create(unsafeGlobal.Object.prototype);
-  const safeEvaluatorFactory = createSafeEvaluatorFactory(unsafeRec, safeGlobal);
+  const safeGlobal = create(unsafeGlobal.Object.prototype, sharedGlobalDescs);
+
+  const safeEvaluatorFactory =
+        createSafeEvaluatorFactory(unsafeRec, safeGlobal);
   const safeEval = createSafeEvaluator(safeEvaluatorFactory);
   const safeEvalWhichTakesEndowments =
         createSafeEvaluatorWhichTakesEndowments(safeEvaluatorFactory);
   const safeFunction = createFunctionEvaluator(unsafeRec, safeEval);
 
-  setDefaultBindings(sharedGlobalDescs, safeGlobal, safeEval, safeFunction);
+  setDefaultBindings(safeGlobal, safeEval, safeFunction);
 
   const realmRec = freeze({
     safeGlobal,

--- a/src/realm.js
+++ b/src/realm.js
@@ -55,9 +55,8 @@ function createRealmRec(unsafeRec) {
   const safeGlobal = create(unsafeGlobal.Object.prototype);
   const safeEvaluatorFactory = createSafeEvaluatorFactory(unsafeRec, safeGlobal);
   const safeEval = createSafeEvaluator(safeEvaluatorFactory);
-  const safeEvalWhichTakesEndowments = createSafeEvaluatorWhichTakesEndowments(
-    safeEvaluatorFactory
-  );
+  const safeEvalWhichTakesEndowments =
+        createSafeEvaluatorWhichTakesEndowments(safeEvaluatorFactory);
   const safeFunction = createFunctionEvaluator(unsafeRec, safeEval);
 
   setDefaultBindings(sharedGlobalDescs, safeGlobal, safeEval, safeFunction);

--- a/src/realmFacade.js
+++ b/src/realmFacade.js
@@ -4,7 +4,12 @@ import { cleanupSource } from './utilities';
 // never referenced again, because it closes over the wrong intrinsics
 
 export function buildChildRealm(unsafeRec, BaseRealm) {
-  const { initRootRealm, initCompartment, getRealmGlobal, realmEvaluate } = BaseRealm;
+  const {
+    initRootRealm,
+    initCompartment,
+    getRealmGlobal,
+    realmEvaluate
+  } = BaseRealm;
 
   // This Object and Reflect are brand new, from a new unsafeRec, so no user
   // code has been run or had a chance to manipulate them. We extract these
@@ -136,7 +141,8 @@ export function buildChildRealm(unsafeRec, BaseRealm) {
 // The parentheses means we don't bind the 'buildChildRealm' name inside the
 // child's namespace. this would accept an anonymous function declaration.
 // function expression (not a declaration) so it has a completion value.
-const buildChildRealmString = cleanupSource(`'use strict'; (${buildChildRealm})`);
+const buildChildRealmString =
+      cleanupSource(`'use strict'; (${buildChildRealm})`);
 
 export function createRealmFacade(unsafeRec, BaseRealm) {
   const { unsafeEval } = unsafeRec;

--- a/src/realmFacade.js
+++ b/src/realmFacade.js
@@ -141,8 +141,9 @@ export function buildChildRealm(unsafeRec, BaseRealm) {
 // The parentheses means we don't bind the 'buildChildRealm' name inside the
 // child's namespace. this would accept an anonymous function declaration.
 // function expression (not a declaration) so it has a completion value.
-const buildChildRealmString =
-      cleanupSource(`'use strict'; (${buildChildRealm})`);
+const buildChildRealmString = cleanupSource(
+  `'use strict'; (${buildChildRealm})`
+);
 
 export function createRealmFacade(unsafeRec, BaseRealm) {
   const { unsafeEval } = unsafeRec;

--- a/src/repair/accessors.js
+++ b/src/repair/accessors.js
@@ -11,7 +11,8 @@
  * This function can be used in two ways: (1) invoked directly to fix the primal
  * realm's Object.prototype, and (2) converted to a string to be executed
  * inside each new RootRealm to fix their Object.prototypes. Evaluation requires
- * the function to have no dependencies, so don't import anything from the outside.
+ * the function to have no dependencies, so don't import anything from
+ * the outside.
  */
 
 // todo: this file should be moved out to a separate repo and npm module.
@@ -24,10 +25,11 @@ export function repairAccessors() {
     prototype: objectPrototype
   } = Object;
 
-  // On some platforms, the implementation of these functions act as if they are
-  // in sloppy mode: if they're invoked badly, they will expose the global object,
-  // so we need to repair these for security. Thus it is our responsibility to fix
-  // this, and we need to include repairAccessors. E.g. Chrome in 2016.
+  // On some platforms, the implementation of these functions act as
+  // if they are in sloppy mode: if they're invoked badly, they will
+  // expose the global object, so we need to repair these for
+  // security. Thus it is our responsibility to fix this, and we need
+  // to include repairAccessors. E.g. Chrome in 2016.
 
   try {
     // Verify that the method is not callable.

--- a/src/repair/functions.js
+++ b/src/repair/functions.js
@@ -37,7 +37,8 @@ export function repairFunctions() {
       FunctionInstance = (0, eval)(declaration);
     } catch (e) {
       if (e instanceof SyntaxError) {
-        // Prevent failure on platforms where async and/or generators are not supported.
+        // Prevent failure on platforms where async and/or generators
+        // are not supported.
         return;
       }
       // Re-throw
@@ -55,7 +56,8 @@ export function repairFunctions() {
     // (new Error()).constructors does not inherit from Function, because Error
     // was defined before ES6 classes. So we don't need to repair it too.
 
-    // (Error()).constructor inherit from Function, which gets a tamed constructor here.
+    // (Error()).constructor inherit from Function, which gets a tamed
+    // constructor here.
 
     // todo: in an ES6 class that does not inherit from anything, what does its
     // constructor inherit from? We worry that it inherits from Function, in
@@ -64,11 +66,15 @@ export function repairFunctions() {
 
     // This line replaces the original constructor in the prototype chain
     // with the tamed one. No copy of the original is peserved.
-    defineProperties(FunctionPrototype, { constructor: { value: TamedFunction } });
+    defineProperties(FunctionPrototype, {
+      constructor: { value: TamedFunction }
+    });
 
     // This line sets the tamed constructor's prototype data property to
     // the original one.
-    defineProperties(TamedFunction, { prototype: { value: FunctionPrototype } });
+    defineProperties(TamedFunction, {
+      prototype: { value: FunctionPrototype }
+    });
 
     if (TamedFunction !== Function.prototype.constructor) {
       // Ensures that all functions meet "instanceof Function" in a realm.

--- a/src/scopeHandler.js
+++ b/src/scopeHandler.js
@@ -122,9 +122,10 @@ export function createScopeHandler(unsafeRec) {
     has(target, prop) {
       // proxies stringify 'prop', so no TOCTTOU danger here
 
-      // unsafeGlobal: hide all properties of unsafeGlobal at the expense of 'typeof'
-      // being wrong for those properties. For example, in the browser, evaluating
-      // 'document = 3', will add a property to  safeGlobal instead of throwing a
+      // unsafeGlobal: hide all properties of unsafeGlobal at the
+      // expense of 'typeof' being wrong for those properties. For
+      // example, in the browser, evaluating 'document = 3', will add
+      // a property to safeGlobal instead of throwing a
       // ReferenceError.
       if (prop === 'eval' || prop in target || prop in unsafeGlobal) {
         return true;

--- a/src/scopeHandler.js
+++ b/src/scopeHandler.js
@@ -1,4 +1,4 @@
-import { freeze, getPrototypeOf, objectHasOwnProperty } from './commons';
+import { freeze, objectHasOwnProperty } from './commons';
 import { throwTantrum } from './utilities';
 
 /**
@@ -26,7 +26,7 @@ const alwaysThrowHandler = new Proxy(freeze({}), {
  * - hide the unsafeGlobal which lives on the scope chain above the 'with'.
  * - ensure the Proxy invariants despite some global properties being frozen.
  */
-export function createScopeHandler(unsafeRec) {
+export function createScopeHandler(unsafeRec, safeGlobal) {
   const { unsafeGlobal, unsafeEval } = unsafeRec;
 
   // This flag allow us to determine if the eval() call is an done by the
@@ -90,10 +90,7 @@ export function createScopeHandler(unsafeRec) {
         throw new TypeError(`do not modify endowments like ${String(prop)}`);
       }
 
-      // todo (optimization): keep a reference to the shadow avoids calling
-      // getPrototypeOf on the target every time the set trap is invoked,
-      // since safeGlobal === getPrototypeOf(target).
-      getPrototypeOf(target)[prop] = value;
+      safeGlobal[prop] = value;
 
       // Return true after successful set.
       return true;

--- a/src/sourceParser.js
+++ b/src/sourceParser.js
@@ -13,6 +13,9 @@
 // source file is written strangely to avoid mentioning these
 // character strings explicitly.
 
+// We do not write the regexp in a straightforward way, so that an
+// apparennt html comment does not appear in this file. Thus, we avoid
+// rejection by the overly eager rejectDangerousSources.
 const htmlCommentPattern = new RegExp(`(?:${'<'}!--|--${'>'})`);
 
 function rejectHtmlComments(s) {
@@ -76,7 +79,7 @@ function rejectImportExpressions(s) {
 // occurrences, not malicious one. In particular, `(eval)(...)` is
 // direct eval syntax that would not be caught by the following regexp.
 
-const someDirectEvalPattern = /\beval\s*(?:\(|\/\/|\/\*)/m;
+const someDirectEvalPattern = /\beval\s*(?:\(|\/[/*])/;
 
 function rejectSomeDirectEvalExpressions(s) {
   const index = s.search(someDirectEvalPattern);

--- a/src/sourceParser.js
+++ b/src/sourceParser.js
@@ -1,3 +1,45 @@
+// https://www.ecma-international.org/ecma-262/9.0/index.html#sec-html-like-comments
+// explains that JavaScript parsers may or may not recognize html
+// comment tokens "<" immediately followed by "!--" and "--"
+// immediately followed by ">" in non-module source text, and treat
+// them as a kind of line comment. Since otherwise both of these can
+// appear in normal JavaScript source code as a sequence of operators,
+// we have the terrifying possibility of the same source code parsing
+// one way on one correct JavaScript implementation, and another way
+// on another.
+//
+// This shim takes the conservative strategy of just rejecting source
+// text that contains these strings anywhere. Note that this very
+// source file is written strangely to avoid mentioning these
+// character strings explicitly.
+
+const htmlCommentPattern = new RegExp(`(?:${'<'}!--|--${'>'})`);
+
+function rejectHtmlComments(s) {
+  const index = s.search(htmlCommentPattern);
+  if (index !== -1) {
+    const linenum = s.slice(0, index).split('\n').length; // more or less
+    throw new SyntaxError(
+      `possible html comment syntax rejected around line ${linenum}`);
+  }
+}
+
+
+// The proposed dynamic import expression is the only syntax currently
+// proposed, that can appear in non-module JavaScript code, that
+// enables direct access to the outside world that cannot be
+// surpressed or intercepted without parsing and rewriting. Instead,
+// this shim conservatively rejects any source text that seems to
+// contain such an expression. To do this safely without parsing, we
+// must also reject some valid programs, i.e., those containing
+// apparent import expressions in literal strings or comments.
+
+// The current conservative rule looks for the identifier "import"
+// followed by either an open paren or something that looks like the
+// beginning of a comment. We assume that we do not need to worry
+// about html comment syntax because that was already rejected by
+// rejectHtmlComments.
+
 // this \s *must* match all kinds of syntax-defined whitespace. If e.g.
 // U+2028 (LINE SEPARATOR) or U+2029 (PARAGRAPH SEPARATOR) is treated as
 // whitespace by the parser, but not matched by /\s/, then this would admit
@@ -5,15 +47,50 @@
 // something like that from something like importnotreally('power.js') which
 // is perfectly safe.
 
-const importParser = /\bimport\s*(?:\(|\/[/*])/;
+const importPattern = /\bimport\s*(?:\(|\/[/*])/;
 
-export function rejectImportExpressions(s) {
-  const index = s.search(importParser);
+function rejectImportExpressions(s) {
+  const index = s.search(importPattern);
   if (index !== -1) {
-    // todo: if we have a full parser available, use it here. If there is no
-    // 'import' token in the string, we're safe.
-    // if (!parse(s).includes('import')) return;
     const linenum = s.slice(0, index).split('\n').length; // more or less
-    throw new SyntaxError(`possible import expression rejected around line ${linenum}`);
+    throw new SyntaxError(
+      `possible import expression rejected around line ${linenum}`);
   }
+}
+
+
+// The shim cannot correctly emulate a direct eval as explained at
+// https://github.com/Agoric/realms-shim/issues/12
+// Without rejecting apparent direct eval syntax, we would
+// accidentally evaluate these with an emulation of indirect eval. Tp
+// prevent future compatibility problems, in shifting from use of the
+// shim to genuine platform support for the proposal, we should
+// instead statically reject code that seems to contain a direct eval
+// expression.
+//
+// As with the dynamic import expression, to avoid a full parse, we do
+// this approximately with a regexp, that will also reject strings
+// that appear safely in comments or strings. Unlike dynamic import,
+// if we miss some, this only creates future compat problems, not
+// security problems. Thus, we are only trying to catch innocent
+// occurrences, not malicious one. In particular, `(eval)(...)` is
+// direct eval syntax that would not be caught by the following regexp.
+
+const someDirectEvalPattern = /\beval\s*(?:\(|\/\/|\/\*)/m;
+
+function rejectSomeDirectEvalExpressions(s) {
+  const index = s.search(someDirectEvalPattern);
+  if (index !== -1) {
+    const linenum = s.slice(0, index).split('\n').length; // more or less
+    throw new SyntaxError(
+      `possible direct eval expression rejected around line ${linenum}`);
+  }
+}
+
+
+
+export function rejectDangerousSources(s) {
+  rejectHtmlComments(s);
+  rejectImportExpressions(s);
+  rejectSomeDirectEvalExpressions(s);
 }

--- a/src/sourceParser.js
+++ b/src/sourceParser.js
@@ -20,10 +20,10 @@ function rejectHtmlComments(s) {
   if (index !== -1) {
     const linenum = s.slice(0, index).split('\n').length; // more or less
     throw new SyntaxError(
-      `possible html comment syntax rejected around line ${linenum}`);
+      `possible html comment syntax rejected around line ${linenum}`
+    );
   }
 }
-
 
 // The proposed dynamic import expression is the only syntax currently
 // proposed, that can appear in non-module JavaScript code, that
@@ -54,10 +54,10 @@ function rejectImportExpressions(s) {
   if (index !== -1) {
     const linenum = s.slice(0, index).split('\n').length; // more or less
     throw new SyntaxError(
-      `possible import expression rejected around line ${linenum}`);
+      `possible import expression rejected around line ${linenum}`
+    );
   }
 }
-
 
 // The shim cannot correctly emulate a direct eval as explained at
 // https://github.com/Agoric/realms-shim/issues/12
@@ -83,11 +83,10 @@ function rejectSomeDirectEvalExpressions(s) {
   if (index !== -1) {
     const linenum = s.slice(0, index).split('\n').length; // more or less
     throw new SyntaxError(
-      `possible direct eval expression rejected around line ${linenum}`);
+      `possible direct eval expression rejected around line ${linenum}`
+    );
   }
 }
-
-
 
 export function rejectDangerousSources(s) {
   rejectHtmlComments(s);

--- a/src/stdlib.js
+++ b/src/stdlib.js
@@ -109,8 +109,10 @@ export function getSharedGlobalDescs(unsafeGlobal) {
         // Abort if an accessor is found on the unsafe global object
         // instead of a data property. We should never get into this
         // non standard situation.
-        assert('value' in desc,
-               `unexpected accessor on global property: ${name}`);
+        assert(
+          'value' in desc,
+          `unexpected accessor on global property: ${name}`
+        );
 
         descriptors[name] = {
           value: desc.value,

--- a/src/stdlib.js
+++ b/src/stdlib.js
@@ -127,7 +127,10 @@ export function getSharedGlobalDescs(unsafeGlobal) {
   describe(frozenGlobalPropertyNames, false, false, false);
   // The following is correct but expensive.
   // describe(stableGlobalPropertyNames, true, false, true);
-  // Instead, for now, we let these get optimized
+  // Instead, for now, we let these get optimized.
+  //
+  // TODO: We should provide an option to turn this optimization off,
+  // by feeding "true, false, true" here instead.
   describe(stableGlobalPropertyNames, false, false, false);
   // These we keep replaceable and removable, because we expect
   // others, e.g., SES, may want to do so.

--- a/src/stdlib.js
+++ b/src/stdlib.js
@@ -1,10 +1,24 @@
 import { getOwnPropertyDescriptor } from './commons';
 import { assert } from './utilities';
 
+// These value properties of the global object are non-writable,
+// non-configurable data properties.
+const frozenGlobalPropertyNames = [
+  // *** 18.1 Value Properties of the Global Object
+
+  'Infinity',
+  'NaN',
+  'undefined'
+];
+
 // All the following stdlib items have the same name on both our intrinsics
 // object and on the global object. Unlike Infinity/NaN/undefined, these
-// should all be writable and configurable.
-const sharedGlobalPropertyNames = [
+// should all be writable and configurable. This is divided into two
+// sets. The stable ones are those the shim can freeze early because
+// we don't expect anyone will want to mutate them. The unstable ones
+// are the ones that we correctly initialize to writable and
+// configurable so that they can still be replaced or removed.
+const stableGlobalPropertyNames = [
   // *** 18.2 Function Properties of the Global Object
 
   // 'eval', // comes from safeEval instead
@@ -24,25 +38,25 @@ const sharedGlobalPropertyNames = [
   'ArrayBuffer',
   'Boolean',
   'DataView',
-  'Date',
-  'Error',
+  // 'Date',  // Unstable
+  // 'Error',  // Unstable
   'EvalError',
   'Float32Array',
   'Float64Array',
-  // 'Function', // comes from safeFunction instead
+  // 'Function',  // comes from safeFunction instead
   'Int8Array',
   'Int16Array',
   'Int32Array',
   'Map',
   'Number',
   'Object',
-  'Promise',
-  'Proxy',
+  // 'Promise',  // Unstable
+  // 'Proxy',  // Unstable
   'RangeError',
   'ReferenceError',
-  'RegExp',
+  // 'RegExp',  // Unstable
   'Set',
-  // 'SharedArrayBuffer' // removed on Jan 5, 2018
+  // 'SharedArrayBuffer'  // removed on Jan 5, 2018
   'String',
   'Symbol',
   'SyntaxError',
@@ -65,39 +79,57 @@ const sharedGlobalPropertyNames = [
   // *** Annex B
 
   'escape',
-  'unescape',
+  'unescape'
 
   // *** ECMA-402
 
-  'Intl'
+  // 'Intl'  // Unstable
 
   // *** ESNext
 
   // 'Realm' // Comes from createRealmGlobalObject()
 ];
 
+const unstableGlobalPropertyNames = [
+  'Date',
+  'Error',
+  'Promise',
+  'Proxy',
+  'RegExp',
+  'Intl'
+];
+
 export function getSharedGlobalDescs(unsafeGlobal) {
-  const descriptors = {
-    // *** 18.1 Value Properties of the Global Object
-    Infinity: { value: Infinity },
-    NaN: { value: NaN },
-    undefined: { value: undefined }
-  };
+  const descriptors = {};
 
-  for (const name of sharedGlobalPropertyNames) {
-    const desc = getOwnPropertyDescriptor(unsafeGlobal, name);
-    if (desc) {
-      // Abort if an accessor is found on the unsafe global object instead of a
-      // data property. We should never get into this non standard situation.
-      assert('value' in desc, `unexpected accessor on global property: ${name}`);
+  function describe(names, writable, enumerable, configurable) {
+    for (const name of names) {
+      const desc = getOwnPropertyDescriptor(unsafeGlobal, name);
+      if (desc) {
+        // Abort if an accessor is found on the unsafe global object
+        // instead of a data property. We should never get into this
+        // non standard situation.
+        assert('value' in desc,
+               `unexpected accessor on global property: ${name}`);
 
-      descriptors[name] = {
-        value: desc.value,
-        writable: true,
-        configurable: true
-      };
+        descriptors[name] = {
+          value: desc.value,
+          writable,
+          enumerable,
+          configurable
+        };
+      }
     }
   }
+
+  describe(frozenGlobalPropertyNames, false, false, false);
+  // The following is correct but expensive.
+  // describe(stableGlobalPropertyNames, true, false, true);
+  // Instead, for now, we let these get optimized
+  describe(stableGlobalPropertyNames, false, false, false);
+  // These we keep replaceable and removable, because we expect
+  // others, e.g., SES, may want to do so.
+  describe(unstableGlobalPropertyNames, true, false, true);
 
   return descriptors;
 }

--- a/src/unsafeRec.js
+++ b/src/unsafeRec.js
@@ -18,12 +18,13 @@ const unsafeGlobalEvalSrc = `(0, eval)("'use strict'; this")`;
 
 // This method is only exported for testing purposes.
 export function createNewUnsafeGlobalForNode() {
-  // Note that webpack and others will shim 'vm' including the method 'runInNewContext',
-  // so the presence of vm is not a useful check
+  // Note that webpack and others will shim 'vm' including the method
+  // 'runInNewContext', so the presence of vm is not a useful check
 
   // TODO: Find a better test that works with bundlers
   // eslint-disable-next-line no-new-func
-  const isNode = new Function('try {return this===global}catch(e){ return false}')();
+  const isNode = new Function(
+    'try {return this===global}catch(e){return false}')();
 
   if (!isNode) {
     return undefined;
@@ -88,8 +89,10 @@ function createUnsafeRec(unsafeGlobal, allShims = []) {
   });
 }
 
-const repairAccessorsShim = cleanupSource(`"use strict"; (${repairAccessors})();`);
-const repairFunctionsShim = cleanupSource(`"use strict"; (${repairFunctions})();`);
+const repairAccessorsShim =
+      cleanupSource(`"use strict"; (${repairAccessors})();`);
+const repairFunctionsShim =
+      cleanupSource(`"use strict"; (${repairFunctions})();`);
 
 // Create a new unsafeRec from a brand new context, with new intrinsics and a
 // new global object

--- a/src/unsafeRec.js
+++ b/src/unsafeRec.js
@@ -24,7 +24,8 @@ export function createNewUnsafeGlobalForNode() {
   // TODO: Find a better test that works with bundlers
   // eslint-disable-next-line no-new-func
   const isNode = new Function(
-    'try {return this===global}catch(e){return false}')();
+    'try {return this===global}catch(e){return false}'
+  )();
 
   if (!isNode) {
     return undefined;
@@ -89,10 +90,12 @@ function createUnsafeRec(unsafeGlobal, allShims = []) {
   });
 }
 
-const repairAccessorsShim =
-      cleanupSource(`"use strict"; (${repairAccessors})();`);
-const repairFunctionsShim =
-      cleanupSource(`"use strict"; (${repairFunctions})();`);
+const repairAccessorsShim = cleanupSource(
+  `"use strict"; (${repairAccessors})();`
+);
+const repairFunctionsShim = cleanupSource(
+  `"use strict"; (${repairFunctions})();`
+);
 
 // Create a new unsafeRec from a brand new context, with new intrinsics and a
 // new global object

--- a/test/module/accessors.js
+++ b/test/module/accessors.js
@@ -23,7 +23,12 @@ test('repairAccessors - force', specs => {
 
   const {
     create,
-    prototype: { __defineGetter__, __defineSetter__, __lookupGetter__, __lookupSetter__ }
+    prototype: {
+      __defineGetter__,
+      __defineSetter__,
+      __lookupGetter__,
+      __lookupSetter__
+    }
   } = Object;
 
   specs.test('Object#__defineGetter__', t => {
@@ -43,9 +48,17 @@ test('repairAccessors - force', specs => {
     object.key = 44;
     t.ok(object.key === 42 && object.foo === 43, 'works with setter');
 
-    t.throws(() => object.__defineSetter__('foo', undefined), TypeError, 'Throws on not function`');
+    t.throws(
+      () => object.__defineSetter__('foo', undefined),
+      TypeError,
+      'Throws on not function`'
+    );
 
-    t.throws(() => __defineGetter__.call(null, 1, () => {}), TypeError, 'Throws on null as `this`');
+    t.throws(
+      () => __defineGetter__.call(null, 1, () => {}),
+      TypeError,
+      'Throws on null as `this`'
+    );
     t.throws(
       () => __defineGetter__.call(undefined, 1, () => {}),
       TypeError,
@@ -78,9 +91,17 @@ test('repairAccessors - force', specs => {
     object.key = 44;
     t.ok(object.key === 42 && object.foo === 43, 'works with getter');
 
-    t.throws(() => object.__defineSetter__('foo', undefined), TypeError, 'Throws on not function`');
+    t.throws(
+      () => object.__defineSetter__('foo', undefined),
+      TypeError,
+      'Throws on not function`'
+    );
 
-    t.throws(() => __defineSetter__.call(null, 1, () => {}), TypeError, 'Throws on null as `this`');
+    t.throws(
+      () => __defineSetter__.call(null, 1, () => {}),
+      TypeError,
+      'Throws on null as `this`'
+    );
     t.throws(
       () => __defineSetter__.call(undefined, 1, () => {}),
       TypeError,
@@ -96,7 +117,8 @@ test('repairAccessors - force', specs => {
     t.equal(__lookupGetter__.name, '__lookupGetter__');
     // assert.looksNative(__lookupGetter__);
     t.equal(
-      Object.getOwnPropertyDescriptor(Object.prototype, '__lookupGetter__').enumerable,
+      Object.getOwnPropertyDescriptor(Object.prototype, '__lookupGetter__')
+        .enumerable,
       false
     );
     t.equal({}.__lookupGetter__('key'), undefined, 'empty object');
@@ -117,9 +139,17 @@ test('repairAccessors - force', specs => {
 
     t.equal(obj2.__lookupGetter__(symbol2), setter2, 'own getter');
     t.equal(create(obj2).__lookupGetter__(symbol2), setter2, 'proto getter');
-    t.equal(create(obj2).__lookupGetter__(Symbol('foo')), undefined, 'empty proto');
+    t.equal(
+      create(obj2).__lookupGetter__(Symbol('foo')),
+      undefined,
+      'empty proto'
+    );
 
-    t.throws(() => __lookupGetter__.call(null, 1, () => {}), TypeError, 'Throws on null as `this`');
+    t.throws(
+      () => __lookupGetter__.call(null, 1, () => {}),
+      TypeError,
+      'Throws on null as `this`'
+    );
     t.throws(
       () => __lookupGetter__.call(undefined, 1, () => {}),
       TypeError,
@@ -135,7 +165,8 @@ test('repairAccessors - force', specs => {
     t.equal(__lookupSetter__.name, '__lookupSetter__');
     // assert.looksNative(__lookupSetter__);
     t.equal(
-      Object.getOwnPropertyDescriptor(Object.prototype, '__lookupSetter__').enumerable,
+      Object.getOwnPropertyDescriptor(Object.prototype, '__lookupSetter__')
+        .enumerable,
       false
     );
     t.equal({}.__lookupSetter__('key'), undefined, 'empty object');
@@ -156,9 +187,17 @@ test('repairAccessors - force', specs => {
 
     t.equal(obj2.__lookupSetter__(symbol2), setter2, 'own getter');
     t.equal(create(obj2).__lookupSetter__(symbol2), setter2, 'proto getter');
-    t.equal(create(obj2).__lookupSetter__(Symbol('foo')), undefined, 'empty proto');
+    t.equal(
+      create(obj2).__lookupSetter__(Symbol('foo')),
+      undefined,
+      'empty proto'
+    );
 
-    t.throws(() => __lookupSetter__.call(null, 1, () => {}), TypeError, 'Throws on null as `this`');
+    t.throws(
+      () => __lookupSetter__.call(null, 1, () => {}),
+      TypeError,
+      'Throws on null as `this`'
+    );
     t.throws(
       () => __lookupSetter__.call(undefined, 1, () => {}),
       TypeError,

--- a/test/module/evaluators.js
+++ b/test/module/evaluators.js
@@ -7,7 +7,11 @@ import {
   createFunctionEvaluator
 } from '../../src/evaluators';
 
-const unsafeRecord = { unsafeGlobal: {}, unsafeEval: eval, unsafeFunction: Function };
+const unsafeRecord = {
+  unsafeGlobal: {},
+  unsafeEval: eval,
+  unsafeFunction: Function
+};
 
 test('createSafeEvaluator', t => {
   t.plan(27);
@@ -18,8 +22,13 @@ test('createSafeEvaluator', t => {
     throw new TypeError();
   });
 
-  const safeGlobal = Object.create(null, { foo: { value: 1 }, bar: { value: 2, writable: true } });
-  const safeEval = createSafeEvaluator(createSafeEvaluatorFactory(unsafeRecord, safeGlobal));
+  const safeGlobal = Object.create(null, {
+    foo: { value: 1 },
+    bar: { value: 2, writable: true }
+  });
+  const safeEval = createSafeEvaluator(
+    createSafeEvaluatorFactory(unsafeRecord, safeGlobal)
+  );
 
   t.equal(safeEval('foo'), 1);
   t.equal(safeEval('bar'), 2);
@@ -76,7 +85,10 @@ test('createSafeEvaluatorWhichTakesEndowments', t => {
     throw new TypeError();
   });
 
-  const safeGlobal = Object.create(null, { foo: { value: 1 }, bar: { value: 2, writable: true } });
+  const safeGlobal = Object.create(null, {
+    foo: { value: 1 },
+    bar: { value: 2, writable: true }
+  });
   const safeEval = createSafeEvaluatorWhichTakesEndowments(
     createSafeEvaluatorFactory(unsafeRecord, safeGlobal)
   );
@@ -110,8 +122,13 @@ test('createFunctionEvaluator', t => {
     throw new TypeError();
   });
 
-  const safeGlobal = Object.create(null, { foo: { value: 1 }, bar: { value: 2, writable: true } });
-  const safeEval = createSafeEvaluator(createSafeEvaluatorFactory(unsafeRecord, safeGlobal));
+  const safeGlobal = Object.create(null, {
+    foo: { value: 1 },
+    bar: { value: 2, writable: true }
+  });
+  const safeEval = createSafeEvaluator(
+    createSafeEvaluatorFactory(unsafeRecord, safeGlobal)
+  );
   const safeFunction = createFunctionEvaluator(unsafeRecord, safeEval);
 
   t.equal(safeFunction('return foo')(), 1);
@@ -199,7 +216,9 @@ test('createSafeEvaluator - broken', t => {
 
   t.throws(() => {
     // Internally, createSafeEvaluator might use safeEval, so we wrap everything.
-    const safeEval = createSafeEvaluator(createSafeEvaluatorFactory(unsafeRecord, safeGlobal));
+    const safeEval = createSafeEvaluator(
+      createSafeEvaluatorFactory(unsafeRecord, safeGlobal)
+    );
     safeEval('true');
   }, /handler did not revoke useUnsafeEvaluator/);
 

--- a/test/module/functions.js
+++ b/test/module/functions.js
@@ -25,7 +25,10 @@ test('repairFunctions', specs => {
       const proto = Object.getPrototypeOf((0, eval)('(async function() {})'));
       t.throws(() => proto.constructor(''), TypeError);
     } catch (e) {
-      if (e instanceof SyntaxError && e.message.startsWith('Unexpected token')) {
+      if (
+        e instanceof SyntaxError &&
+        e.message.startsWith('Unexpected token')
+      ) {
         t.pass('not supported');
       } else {
         throw e;
@@ -40,7 +43,10 @@ test('repairFunctions', specs => {
       const proto = Object.getPrototypeOf((0, eval)('(function* () {})'));
       t.throws(() => proto.constructor(''), TypeError);
     } catch (e) {
-      if (e instanceof SyntaxError && e.message.startsWith('Unexpected token')) {
+      if (
+        e instanceof SyntaxError &&
+        e.message.startsWith('Unexpected token')
+      ) {
         t.pass('not supported');
       } else {
         throw e;
@@ -55,7 +61,10 @@ test('repairFunctions', specs => {
       const proto = Object.getPrototypeOf((0, eval)('(async function* () {})'));
       t.throws(() => proto.constructor(''), TypeError);
     } catch (e) {
-      if (e instanceof SyntaxError && e.message.startsWith('Unexpected token')) {
+      if (
+        e instanceof SyntaxError &&
+        e.message.startsWith('Unexpected token')
+      ) {
         t.pass('not supported');
       } else {
         throw e;

--- a/test/module/optimizer.js
+++ b/test/module/optimizer.js
@@ -4,16 +4,26 @@ import { getOptimizableGlobals } from '../../src/optimizer';
 test('getOptimizableGlobals', t => {
   t.plan(20);
 
-  t.deepEqual(getOptimizableGlobals({}), [], 'should return empty if no global');
+  t.deepEqual(
+    getOptimizableGlobals({}),
+    [],
+    'should return empty if no global'
+  );
 
-  t.deepEqual(getOptimizableGlobals({ foo: true }), [], 'should reject configurable & writable');
+  t.deepEqual(
+    getOptimizableGlobals({ foo: true }),
+    [],
+    'should reject configurable & writable'
+  );
   t.deepEqual(
     getOptimizableGlobals(Object.create(null, { foo: { value: true } })),
     ['foo'],
     'should return non configurable & non writable'
   );
   t.deepEqual(
-    getOptimizableGlobals(Object.create(null, { foo: { value: true, configurable: true } })),
+    getOptimizableGlobals(
+      Object.create(null, { foo: { value: true, configurable: true } })
+    ),
     [],
     'should reject configurable'
   );
@@ -48,7 +58,11 @@ test('getOptimizableGlobals', t => {
   );
   t.deepEqual(
     getOptimizableGlobals(
-      Object.create(null, { null: { value: true }, true: { value: true }, false: { value: true } })
+      Object.create(null, {
+        null: { value: true },
+        true: { value: true },
+        false: { value: true }
+      })
     ),
     [],
     'should reject literals (reserved)'
@@ -61,7 +75,9 @@ test('getOptimizableGlobals', t => {
     'should reject this and arguments'
   );
   t.deepEqual(
-    getOptimizableGlobals(Object.create(null, { [Symbol.iterator]: { value: true } })),
+    getOptimizableGlobals(
+      Object.create(null, { [Symbol.iterator]: { value: true } })
+    ),
     [],
     'should reject symbols'
   );
@@ -99,13 +115,18 @@ test('getOptimizableGlobals', t => {
   );
 
   t.deepEqual(
-    getOptimizableGlobals(Object.create(null, { foo: { value: true }, bar: { value: true } })),
+    getOptimizableGlobals(
+      Object.create(null, { foo: { value: true }, bar: { value: true } })
+    ),
     ['foo', 'bar'],
     'should return all non configurable & non writable'
   );
   t.deepEqual(
     getOptimizableGlobals(
-      Object.create(null, { foo: { value: true }, bar: { value: true, configurable: true } })
+      Object.create(null, {
+        foo: { value: true },
+        bar: { value: true, configurable: true }
+      })
     ),
     ['foo'],
     'should return only non configurable & non writable'

--- a/test/module/realmFacade.js
+++ b/test/module/realmFacade.js
@@ -72,14 +72,19 @@ test('buildChildRealm - callAndWrapError() error types', t => {
     Realm.makeRootRealm();
   }, /123/);
 
-  [EvalError, RangeError, ReferenceError, SyntaxError, TypeError, URIError].forEach(
-    ErrorConstructor => {
-      t.throws(() => {
-        error = new ErrorConstructor();
-        Realm.makeRootRealm();
-      }, ErrorConstructor);
-    }
-  );
+  [
+    EvalError,
+    RangeError,
+    ReferenceError,
+    SyntaxError,
+    TypeError,
+    URIError
+  ].forEach(ErrorConstructor => {
+    t.throws(() => {
+      error = new ErrorConstructor();
+      Realm.makeRootRealm();
+    }, ErrorConstructor);
+  });
 
   BaseRealm.initRootRealm.restore();
 });

--- a/test/module/scopeHandler.js
+++ b/test/module/scopeHandler.js
@@ -22,7 +22,10 @@ test('scope hander traps', t => {
     'ownKeys',
     'preventExtensions',
     'setPrototypeOf'
-  ].forEach(trap => t.throws(() => handler[trap]), /unexpected scope handler trap called/);
+  ].forEach(
+    trap => t.throws(() => handler[trap]),
+    /unexpected scope handler trap called/
+  );
 
   // eslint-disable-next-line no-console
   console.error.restore();
@@ -85,7 +88,10 @@ test('scope hander et', t => {
   const safeGlobal = { bar: {} };
   const handler = createScopeHandler({ unsafeGlobal }, safeGlobal);
   const endowments = { foo: {} };
-  const target = Object.create(safeGlobal, Object.getOwnPropertyDescriptors(endowments));
+  const target = Object.create(
+    safeGlobal,
+    Object.getOwnPropertyDescriptors(endowments)
+  );
 
   const evil = {};
   handler.set(target, 'eval', evil);
@@ -96,7 +102,10 @@ test('scope hander et', t => {
   t.equal(safeGlobal.bar, bar);
 
   const foo = {};
-  t.throws(() => handler.set(target, 'foo', foo), /do not modify endowments like foo/);
+  t.throws(
+    () => handler.set(target, 'foo', foo),
+    /do not modify endowments like foo/
+  );
 
   t.equal(Object.keys(unsafeGlobal).length, 0);
 });

--- a/test/module/stdlib.js
+++ b/test/module/stdlib.js
@@ -5,11 +5,15 @@ import { getSharedGlobalDescs } from '../../src/stdlib';
 test('Global default values', t => {
   const mockGlobal = {
     // frozen names
-    Infinity, NaN, undefined,
+    Infinity,
+    NaN,
+    undefined,
     // stable names. Should be mutable but frozen in the shim for speed
-    JSON: {}, Math: {},
+    JSON: {},
+    Math: {},
     // unstable names.
-    Date: {}, Error: {}
+    Date: {},
+    Error: {}
   };
   const descs = getSharedGlobalDescs(mockGlobal);
 
@@ -53,8 +57,10 @@ test('Global accessor throws', t => {
     }
   });
 
-  t.throws(() => getSharedGlobalDescs(mockGlobal),
-           /unexpected accessor on global property: JSON/);
+  t.throws(
+    () => getSharedGlobalDescs(mockGlobal),
+    /unexpected accessor on global property: JSON/
+  );
 
   // eslint-disable-next-line no-console
   t.equals(console.error.callCount, 1);

--- a/test/module/unsafeRec.js
+++ b/test/module/unsafeRec.js
@@ -12,7 +12,13 @@ test('createNewUnsafeRec', t => {
   t.plan(7);
 
   const unsafeRec = createNewUnsafeRec();
-  const { unsafeGlobal, sharedGlobalDescs, unsafeEval, unsafeFunction, allShims } = unsafeRec;
+  const {
+    unsafeGlobal,
+    sharedGlobalDescs,
+    unsafeEval,
+    unsafeFunction,
+    allShims
+  } = unsafeRec;
 
   t.ok(Object.isFrozen(unsafeRec));
 
@@ -44,10 +50,13 @@ test('createNewUnsafeGlobalForNode on node', t => {
   t.ok(unsafeGlobal instanceof unsafeGlobal.Object, 'global must be an Object');
   t.notOk(unsafeGlobal instanceof Object, 'must not be Object in this realm');
 
-  t.ok(unsafeGlobal.eval instanceof unsafeGlobal.Function, 'must provide eval() function');
-  t.notOk(unsafeGlobal.eval instanceof Function, 'eval() must not be Function in this realm');
+  t.ok(unsafeGlobal.eval instanceof unsafeGlobal.Function,
+       'must provide eval() function');
+  t.notOk(unsafeGlobal.eval instanceof Function,
+          'eval() must not be Function in this realm');
 
-  t.ok(unsafeGlobal.Function instanceof unsafeGlobal.Function, 'must provide Function() function');
+  t.ok(unsafeGlobal.Function instanceof unsafeGlobal.Function,
+       'must provide Function() function');
   t.notOk(
     unsafeGlobal.Function instanceof Function,
     'Function() must not be Function in this realm'

--- a/test/module/unsafeRec.js
+++ b/test/module/unsafeRec.js
@@ -25,8 +25,9 @@ test('createNewUnsafeRec', t => {
   // todo: more thorough test of descriptors.
   t.deepEqual(sharedGlobalDescs.Object, {
     value: unsafeGlobal.Object,
-    configurable: true,
-    writable: true
+    configurable: false,
+    enumerable: false,
+    writable: false
   });
   t.equal(unsafeEval, unsafeGlobal.eval);
   t.deepEqual(unsafeFunction, unsafeGlobal.Function);

--- a/test/module/unsafeRec.js
+++ b/test/module/unsafeRec.js
@@ -51,13 +51,19 @@ test('createNewUnsafeGlobalForNode on node', t => {
   t.ok(unsafeGlobal instanceof unsafeGlobal.Object, 'global must be an Object');
   t.notOk(unsafeGlobal instanceof Object, 'must not be Object in this realm');
 
-  t.ok(unsafeGlobal.eval instanceof unsafeGlobal.Function,
-       'must provide eval() function');
-  t.notOk(unsafeGlobal.eval instanceof Function,
-          'eval() must not be Function in this realm');
+  t.ok(
+    unsafeGlobal.eval instanceof unsafeGlobal.Function,
+    'must provide eval() function'
+  );
+  t.notOk(
+    unsafeGlobal.eval instanceof Function,
+    'eval() must not be Function in this realm'
+  );
 
-  t.ok(unsafeGlobal.Function instanceof unsafeGlobal.Function,
-       'must provide Function() function');
+  t.ok(
+    unsafeGlobal.Function instanceof unsafeGlobal.Function,
+    'must provide Function() function'
+  );
   t.notOk(
     unsafeGlobal.Function instanceof Function,
     'Function() must not be Function in this realm'

--- a/test/module/utilities.js
+++ b/test/module/utilities.js
@@ -9,10 +9,16 @@ test('throwTantrum', t => {
 
   sinon.stub(console, 'error').callsFake();
 
-  t.throws(() => throwTantrum('foo'), /^please report internal shim error: foo$/);
+  t.throws(
+    () => throwTantrum('foo'),
+    /^please report internal shim error: foo$/
+  );
 
   t.equals(console.error.callCount, 1);
-  t.equals(console.error.getCall(0).args[0], 'please report internal shim error: foo');
+  t.equals(
+    console.error.getCall(0).args[0],
+    'please report internal shim error: foo'
+  );
 
   console.error.restore();
 });
@@ -22,10 +28,16 @@ test('throwTantrum', t => {
 
   sinon.stub(console, 'error');
 
-  t.throws(() => throwTantrum('foo', new Error('bar')), /^please report internal shim error: foo$/);
+  t.throws(
+    () => throwTantrum('foo', new Error('bar')),
+    /^please report internal shim error: foo$/
+  );
 
   t.equals(console.error.callCount, 3);
-  t.equals(console.error.getCall(0).args[0], 'please report internal shim error: foo');
+  t.equals(
+    console.error.getCall(0).args[0],
+    'please report internal shim error: foo'
+  );
   t.equals(console.error.getCall(1).args[0], 'Error: bar');
   t.ok(console.error.getCall(2).args[0].includes('at t.throws'));
 
@@ -38,10 +50,16 @@ test('assert', t => {
   sinon.stub(console, 'error').callsFake();
 
   t.doesNotThrow(() => assert(true, 'foo'));
-  t.throws(() => assert(false, 'foo'), /^please report internal shim error: foo$/);
+  t.throws(
+    () => assert(false, 'foo'),
+    /^please report internal shim error: foo$/
+  );
 
   t.equals(console.error.callCount, 1);
-  t.equals(console.error.getCall(0).args[0], 'please report internal shim error: foo');
+  t.equals(
+    console.error.getCall(0).args[0],
+    'please report internal shim error: foo'
+  );
 
   console.error.restore();
 });

--- a/test/realm/function-eval.js
+++ b/test/realm/function-eval.js
@@ -162,7 +162,7 @@ test('frozen-eval', t => {
   desc.configurable = false;
   Object.defineProperty(r.global, 'eval', desc);
 
-  t.equal(r.evaluate('eval(1)'), 1);
+  t.equal(r.evaluate('(0,eval)(1)'), 1);
 
   t.end();
 });

--- a/test/realm/function-eval.js
+++ b/test/realm/function-eval.js
@@ -104,7 +104,10 @@ test('function-reject-paren-default', t => {
   // this ought to be accepted, but our shim is conservative about parenthesis
   const r = Realm.makeRootRealm();
   const goodFunc = 'return foo';
-  t.throws(() => new r.global.Function('foo, a = new Date(0)', goodFunc), r.global.SyntaxError);
+  t.throws(
+    () => new r.global.Function('foo, a = new Date(0)', goodFunc),
+    r.global.SyntaxError
+  );
   t.end();
 });
 
@@ -121,14 +124,20 @@ test('function-default-parameters', t => {
 test('function-rest-parameters', t => {
   const goodFunc = 'return rest[0] + rest[1]';
   const r = Realm.makeRootRealm();
-  t.throws(() => new r.global.Function('...rest', goodFunc), r.global.SyntaxError);
+  t.throws(
+    () => new r.global.Function('...rest', goodFunc),
+    r.global.SyntaxError
+  );
   t.end();
 });
 
 test('function-destructuring-parameters', t => {
   const goodFunc = 'return foo + bar + baz';
   const r = Realm.makeRootRealm();
-  t.throws(() => new r.global.Function('{foo, bar}, baz', goodFunc), r.global.SyntaxError);
+  t.throws(
+    () => new r.global.Function('{foo, bar}, baz', goodFunc),
+    r.global.SyntaxError
+  );
   t.end();
 });
 
@@ -139,7 +148,10 @@ test('function-legitimate-but-weird-parameters', t => {
   t.equal(f1(1, 2, 3), 6);
 
   const goodFunc2 = 'return foo + bar[0] + bar[1]';
-  t.throws(() => new r.global.Function('foo, bar = [1', '2]', goodFunc2), r.global.SyntaxError);
+  t.throws(
+    () => new r.global.Function('foo, bar = [1', '2]', goodFunc2),
+    r.global.SyntaxError
+  );
 
   t.end();
 });

--- a/test/realm/identity-compartment.js
+++ b/test/realm/identity-compartment.js
@@ -9,7 +9,7 @@ test('identity JSON', t => {
   const r2 = r1.global.Realm.makeCompartment();
 
   t.equal(r2.evaluate('JSON'), r2.evaluate('JSON'));
-  t.equal(r2.evaluate('JSON'), r2.evaluate('eval("JSON")'));
+  t.equal(r2.evaluate('JSON'), r2.evaluate('(1,eval)("JSON")'));
   t.notEqual(r2.evaluate('JSON'), JSON);
   t.equal(r2.evaluate('JSON'), r1.evaluate('JSON'));
 });

--- a/test/realm/identity-single.js
+++ b/test/realm/identity-single.js
@@ -8,7 +8,7 @@ test('identity JSON', t => {
   const r = Realm.makeRootRealm();
 
   t.equal(r.evaluate('JSON'), r.evaluate('JSON'));
-  t.equal(r.evaluate('JSON'), r.evaluate('eval("JSON")'));
+  t.equal(r.evaluate('JSON'), r.evaluate('(1,eval)("JSON")'));
   t.equal(r.evaluate('JSON'), r.evaluate('(new Function("return JSON"))()'));
   t.equal(r.evaluate('JSON'), r.global.JSON);
   t.notEqual(r.evaluate('JSON'), JSON);

--- a/test/realm/leak-error.js
+++ b/test/realm/leak-error.js
@@ -86,7 +86,9 @@ test('eval() should yield useful stack trace', t => {
   const r = Realm.makeRootRealm();
   // t.throws() doesn't provide a way to look a e.stack
   function outer8155() {
-    r.evaluate('function inner9184() { throw TypeError("yes1773"); } inner9184()');
+    r.evaluate(
+      'function inner9184() { throw TypeError("yes1773"); } inner9184()'
+    );
   }
   try {
     outer8155();

--- a/test/realm/mutable.js
+++ b/test/realm/mutable.js
@@ -5,8 +5,8 @@ test('most Realm globals are mutable', t => {
   t.plan(3);
   const r = Realm.makeRootRealm();
 
-  r.evaluate('decodeURI = function(uri) { return "decoded" }');
-  t.equal(r.evaluate('decodeURI("http://example.org/")'), 'decoded');
+  r.evaluate('Date = function() { return "bogus" }');
+  t.equal(r.evaluate('Date()'), 'bogus');
 
   r.evaluate('Math.embiggen = function(a) { return a+1 }');
   t.equal(r.evaluate('Math.embiggen(1)'), 2);

--- a/test/realm/test-html-comment.js
+++ b/test/realm/test-html-comment.js
@@ -1,0 +1,75 @@
+import test from 'tape';
+import Realm from '../../src/realm';
+import { rejectDangerousSources } from '../../src/sourceParser';
+
+// We break up the following literal strings so that an apparent html
+// comment does not appear in this file. Thus, we avoid rejection by
+// the overly eager rejectDangerousSources.
+
+const htmlOpenComment = `const a = foo ${'<'}!-- hah
+('evil')`;
+
+const htmlCloseComment = `const a = foo --${'>'} hah
+('evil')`;
+
+test('no-html-comment-expression regexp', t => {
+  t.throws(
+    () => rejectDangerousSources(htmlOpenComment),
+    SyntaxError,
+    'htmlOpenComment'
+  );
+
+  t.throws(
+    () => rejectDangerousSources(htmlCloseComment),
+    SyntaxError,
+    'htmlCloseComment'
+  );
+
+  t.end();
+});
+
+test('reject html comment expressions in evaluate', t => {
+  const r = Realm.makeRootRealm();
+
+  function wrap(s) {
+    return `
+      function name() {
+        ${s};
+        return a;
+      }`;
+  }
+
+  t.throws(
+    () => r.evaluate(wrap(htmlOpenComment)),
+    SyntaxError,
+    'htmlOpenComment'
+  );
+  t.throws(
+    () => r.evaluate(wrap(htmlCloseComment)),
+    SyntaxError,
+    'htmlCloseComment'
+  );
+
+  t.end();
+});
+
+test('reject html comment expressions in Function', t => {
+  const r = Realm.makeRootRealm();
+
+  function wrap(s) {
+    return `new Function("${s}; return a;")`;
+  }
+
+  t.throws(
+    () => r.evaluate(wrap(htmlOpenComment)),
+    SyntaxError,
+    'htmlOpenComment'
+  );
+  t.throws(
+    () => r.evaluate(wrap(htmlCloseComment)),
+    SyntaxError,
+    'htmlCloseComment'
+  );
+
+  t.end();
+});

--- a/test/realm/test-import-expression.js
+++ b/test/realm/test-import-expression.js
@@ -55,6 +55,10 @@ const comment = `const a = import/*hah*/('evil')`;
 const doubleSlashComment = `const a = import // hah
 ('evil')`;
 
+// We break up the following literal strings so that an apparent html
+// comment does not appear in this file. Thus, we avoid rejection by
+// the overly eager rejectDangerousSources.
+
 const htmlOpenComment = `const a = import ${'<'}!-- hah
 ('evil')`;
 
@@ -131,10 +135,8 @@ test('reject import expressions in evaluate', t => {
     SyntaxError,
     'doubleSlashComment'
   );
-  // TODO: Why does the following test case fail even though all the
-  // similar ones succeed?
-  //  t.throws(() => r.evaluate(wrap(htmlOpenComment)),
-  //           SyntaxError, 'htmlOpenComment');
+  t.throws(() => r.evaluate(wrap(htmlOpenComment)),
+           SyntaxError, 'htmlOpenComment');
   t.throws(
     () => r.evaluate(wrap(htmlCloseComment)),
     SyntaxError,

--- a/test/realm/test-import-expression.js
+++ b/test/realm/test-import-expression.js
@@ -80,12 +80,21 @@ test('no-import-expression regexp', t => {
   t.throws(() => rejectDangerousSources(obvious), SyntaxError, 'obvious');
   t.throws(() => rejectDangerousSources(whitespace), SyntaxError, 'whitespace');
   t.throws(() => rejectDangerousSources(comment), SyntaxError, 'comment');
-  t.throws(() => rejectDangerousSources(doubleSlashComment),
-           SyntaxError, 'doubleSlashComment');
-  t.throws(() => rejectDangerousSources(htmlOpenComment),
-           SyntaxError, 'htmlOpenComment');
-  t.throws(() => rejectDangerousSources(htmlCloseComment),
-           SyntaxError, 'htmlCloseComment');
+  t.throws(
+    () => rejectDangerousSources(doubleSlashComment),
+    SyntaxError,
+    'doubleSlashComment'
+  );
+  t.throws(
+    () => rejectDangerousSources(htmlOpenComment),
+    SyntaxError,
+    'htmlOpenComment'
+  );
+  t.throws(
+    () => rejectDangerousSources(htmlCloseComment),
+    SyntaxError,
+    'htmlCloseComment'
+  );
   t.throws(() => rejectDangerousSources(newline), SyntaxError, 'newline');
   t.throws(
     () => rejectDangerousSources(multiline),
@@ -117,14 +126,20 @@ test('reject import expressions in evaluate', t => {
   t.throws(() => r.evaluate(wrap(obvious)), SyntaxError, 'obvious');
   t.throws(() => r.evaluate(wrap(whitespace)), SyntaxError, 'whitespace');
   t.throws(() => r.evaluate(wrap(comment)), SyntaxError, 'comment');
-  t.throws(() => r.evaluate(wrap(doubleSlashComment)),
-           SyntaxError, 'doubleSlashComment');
+  t.throws(
+    () => r.evaluate(wrap(doubleSlashComment)),
+    SyntaxError,
+    'doubleSlashComment'
+  );
   // TODO: Why does the following test case fail even though all the
   // similar ones succeed?
-//  t.throws(() => r.evaluate(wrap(htmlOpenComment)),
-//           SyntaxError, 'htmlOpenComment');
-  t.throws(() => r.evaluate(wrap(htmlCloseComment)),
-           SyntaxError, 'htmlCloseComment');
+  //  t.throws(() => r.evaluate(wrap(htmlOpenComment)),
+  //           SyntaxError, 'htmlOpenComment');
+  t.throws(
+    () => r.evaluate(wrap(htmlCloseComment)),
+    SyntaxError,
+    'htmlCloseComment'
+  );
   t.throws(() => r.evaluate(wrap(newline)), SyntaxError, 'newline');
 
   t.end();
@@ -143,12 +158,21 @@ test('reject import expressions in Function', t => {
   t.throws(() => r.evaluate(wrap(obvious)), SyntaxError, 'obvious');
   t.throws(() => r.evaluate(wrap(whitespace)), SyntaxError, 'whitespace');
   t.throws(() => r.evaluate(wrap(comment)), SyntaxError, 'comment');
-  t.throws(() => r.evaluate(wrap(doubleSlashComment)),
-           SyntaxError, 'doubleSlashComment');
-  t.throws(() => r.evaluate(wrap(htmlOpenComment)),
-           SyntaxError, 'htmlOpenComment');
-  t.throws(() => r.evaluate(wrap(htmlCloseComment)),
-           SyntaxError, 'htmlCloseComment');
+  t.throws(
+    () => r.evaluate(wrap(doubleSlashComment)),
+    SyntaxError,
+    'doubleSlashComment'
+  );
+  t.throws(
+    () => r.evaluate(wrap(htmlOpenComment)),
+    SyntaxError,
+    'htmlOpenComment'
+  );
+  t.throws(
+    () => r.evaluate(wrap(htmlCloseComment)),
+    SyntaxError,
+    'htmlCloseComment'
+  );
   t.throws(() => r.evaluate(wrap(newline)), SyntaxError, 'newline');
 
   t.end();

--- a/test/realm/test-shims.js
+++ b/test/realm/test-shims.js
@@ -36,7 +36,9 @@ test('shims: two shims', t => {
 
 test('shims: inherited shims', t => {
   const r1 = Realm.makeRootRealm({ shims: [shim1] });
-  const r2 = r1.evaluate(`Realm.makeRootRealm({shims: [${JSON.stringify(shim2)}]})`);
+  const r2 = r1.evaluate(
+    `Realm.makeRootRealm({shims: [${JSON.stringify(shim2)}]})`
+  );
   t.equal(r1.global.kilroy, 'was here');
   t.equal(r2.global.kilroy, 'was here but he left');
 

--- a/test/test262/annexB/built-ins/Object/prototype/__defineGetter__/define-non-configurable.js
+++ b/test/test262/annexB/built-ins/Object/prototype/__defineGetter__/define-non-configurable.js
@@ -16,7 +16,10 @@ test('test262/annexB/built-ins/Object/prototype/__defineGetter__/define-non-conf
 
   const test = () => {
     const noop = function() {};
-    const subject = Object.defineProperty({}, 'attr', { value: 1, configurable: false });
+    const subject = Object.defineProperty({}, 'attr', {
+      value: 1,
+      configurable: false
+    });
 
     // eslint-disable-next-line no-restricted-properties, no-underscore-dangle
     t.equal(typeof Object.prototype.__defineGetter__, 'function');

--- a/test/test262/annexB/built-ins/Object/prototype/__defineSetter__/define-non-configurable.js
+++ b/test/test262/annexB/built-ins/Object/prototype/__defineSetter__/define-non-configurable.js
@@ -16,7 +16,10 @@ test('test262/annexB/built-ins/Object/prototype/__defineSetter__/define-non-conf
 
   const test = () => {
     const noop = function() {};
-    const subject = Object.defineProperty({}, 'attr', { value: 1, configurable: false });
+    const subject = Object.defineProperty({}, 'attr', {
+      value: 1,
+      configurable: false
+    });
 
     // eslint-disable-next-line no-restricted-properties, no-underscore-dangle
     t.equal(typeof Object.prototype.__defineSetter__, 'function');


### PR DESCRIPTION
"reject html comments and direct eval" adds these cases to the quick reject rules we're using to guard safeEval. Html comments enables one source to have two parsings, depending on whether the engine implements that part of Annex B. As with the exiting rejection of the dynamic import expression, this uses a conservative regexp that must reject all actual cases, but might also reject inappropriate cases, which are hopefully rare. Rejecting the "direct eval" syntax is not a security issue, just a future compat issue, so this regexp can make failures of inclusion and exclusion.

"Make stable globals fast" divides the stdlib globals into three sets: frozen (like `NaN`), stable (like `Object`) and unstable (like `Date`). We reorder realm initialization so that both the frozen and stable globals are non-writable and thus optimized. The unstable ones are those that shims (like SES) may wish to replace, so these are not optimized.

The "should just be manual reformattings" and "reformat to 80 columns automatically" are non-semantic. The first is just an artifact of my edit history. The second changes the .prettier setting to 80 and reformats everything accordingly.
