### PR TITLE
fix `this` binding in Function constructor

### DIFF
--- a/src/evaluators.js
+++ b/src/evaluators.js
@@ -253,9 +253,12 @@ export function createFunctionEvaluator(unsafeRec, safeEval, realmGlobal) {
       return fn;
     }
     // we fix the `this` binding in Function().
+    // note: In non-strict mode, if `this` is not object
+    // it will be wrapped by Object(). Like 1 becomes Object(1) which is Number(1)
+    // Should we simulate this? It seems like no one will rely on this.
     const bindThis = `(function (globalThis, f) {
   function f2() {
-    return Reflect.apply(f, this || globalThis, arguments);
+    return Reflect.apply(f, this === undefined ? globalThis : this, arguments);
   }
   f2.toString = () => f.toString();
   return f2;

--- a/src/realm.js
+++ b/src/realm.js
@@ -65,7 +65,7 @@ function createRealmRec(unsafeRec, transforms, sloppyGlobals) {
   const safeEvalWhichTakesEndowments = createSafeEvaluatorWhichTakesEndowments(
     safeEvaluatorFactory
   );
-  const safeFunction = createFunctionEvaluator(unsafeRec, safeEval);
+  const safeFunction = createFunctionEvaluator(unsafeRec, safeEval, safeGlobal);
 
   setDefaultBindings(safeGlobal, safeEval, safeFunction);
 

--- a/test/realm/test-confinement.js
+++ b/test/realm/test-confinement.js
@@ -1,15 +1,21 @@
 import test from 'tape';
 import Realm from '../../src/realm';
 
+test('non-strict mode this binding in Function constructor', t => {
+  t.plan(1);
+
+  const r = Realm.makeRootRealm();
+  t.equal(r.evaluate('(new Function("return this"))()'), r.global);
+});
+
 test('confinement evaluation strict mode', t => {
-  t.plan(3);
+  t.plan(2);
 
   const r = Realm.makeRootRealm();
 
   t.equal(r.evaluate('(function() { return this })()'), undefined);
-  t.equal(r.evaluate('(new Function("return this"))()'), r.global);
   t.equal(
-    r.evaluate('(new Function("\\"use strict\\";return this"))()'),
+    r.evaluate(`(new Function('"use strict"; return this'))()`),
     undefined
   );
 });
@@ -18,9 +24,9 @@ test('constructor this binding', t => {
   const r = Realm.makeRootRealm();
   const F = r.evaluate('(new Function("return this"))');
 
-  t.equal(F(), undefined);
+  t.equal(F(), r.global);
   t.equal(F.call(8), 8);
-  t.equal(F.call(undefined), undefined);
+  t.equal(F.call(undefined), r.global);
   t.equal(Reflect.apply(F, 8, []), 8);
 
   const x = { F };

--- a/test/realm/test-confinement.js
+++ b/test/realm/test-confinement.js
@@ -2,12 +2,16 @@ import test from 'tape';
 import Realm from '../../src/realm';
 
 test('confinement evaluation strict mode', t => {
-  t.plan(2);
+  t.plan(3);
 
   const r = Realm.makeRootRealm();
 
   t.equal(r.evaluate('(function() { return this })()'), undefined);
-  t.equal(r.evaluate('(new Function("return this"))()'), undefined);
+  t.equal(r.evaluate('(new Function("return this"))()'), r.global);
+  t.equal(
+    r.evaluate('(new Function("\\"use strict\\";return this"))()'),
+    undefined
+  );
 });
 
 test('constructor this binding', t => {


### PR DESCRIPTION
- [x] fix: this binding in Function

Other unrelated fixes are move to other prs
- [x] <del>fix: pollution to outside world Function.prototype.constructor</del> (see #63 )
- [x] <del>disabled rejectHtmlComments and rejectImportExpressions</del> (see #42 )
- [x] <del>non-strict assignment</del> (see #33 )
- [x] <del>disabled alwaysThrowHandler on WKWebKit</del> (see #62 )