### PR TITLE
add testcase for other Function this bindings

### DIFF
--- a/src/evaluators.js
+++ b/src/evaluators.js
@@ -210,7 +210,6 @@ export function createFunctionEvaluator(unsafeRec, safeEval) {
       functionParams += '\n/*``*/';
     }
 
-    // todo: fix `this` binding in Function().
     const src = `(function(${functionParams}){\n${functionBody}\n})`;
 
     return safeEval(src);

--- a/test/realm/test-confinement.js
+++ b/test/realm/test-confinement.js
@@ -16,6 +16,7 @@ test('constructor this binding', t => {
 
   t.equal(F(), undefined);
   t.equal(F.call(8), 8);
+  t.equal(F.call(undefined), undefined);
   t.equal(Reflect.apply(F, 8, []), 8);
 
   const x = { F };

--- a/test/realm/test-confinement.js
+++ b/test/realm/test-confinement.js
@@ -10,6 +10,20 @@ test('confinement evaluation strict mode', t => {
   t.equal(r.evaluate('(new Function("return this"))()'), undefined);
 });
 
+test('constructor this binding', t => {
+  const r = Realm.makeRootRealm();
+  const F = r.evaluate('(new Function("return this"))');
+
+  t.equal(F(), undefined);
+  t.equal(F.call(8), 8);
+  t.equal(Reflect.apply(F, 8, []), 8);
+
+  const x = { F };
+  t.equal(x.F(), x);
+
+  t.end();
+});
+
 test('confinement evaluation constructor', t => {
   t.plan(2);
 


### PR DESCRIPTION
https://github.com/Agoric/realms-shim/pull/17 raises the issue of the `this` binding of `Function` constructor.

We had missing test cases, whose absence would be informative on that PR. This PR adds those test cases.