### PR TITLE
generic source transforms

### DIFF
--- a/src/realmFacade.js
+++ b/src/realmFacade.js
@@ -92,10 +92,12 @@ export function buildChildRealm(unsafeRec, BaseRealm) {
       return r;
     }
 
-    static makeCompartment() {
+    static makeCompartment(options) {
+      options = Object(options); // todo: sanitize
+
       // Bypass the constructor.
       const r = create(Realm.prototype);
-      callAndWrapError(initCompartment, unsafeRec, r);
+      callAndWrapError(initCompartment, unsafeRec, r, options);
       return r;
     }
 
@@ -111,9 +113,9 @@ export function buildChildRealm(unsafeRec, BaseRealm) {
       return callAndWrapError(getRealmGlobal, this);
     }
 
-    evaluate(x, endowments) {
+    evaluate(x, endowments, options = {}) {
       // safe against strange 'this', as above
-      return callAndWrapError(realmEvaluate, this, x, endowments);
+      return callAndWrapError(realmEvaluate, this, x, endowments, options);
     }
   }
 

--- a/src/realmFacade.js
+++ b/src/realmFacade.js
@@ -82,9 +82,8 @@ export function buildChildRealm(unsafeRec, BaseRealm) {
       throw new TypeError('Realm is not a constructor');
     }
 
-    static makeRootRealm(options) {
+    static makeRootRealm(options = {}) {
       // This is the exposed interface.
-      options = Object(options); // todo: sanitize
 
       // Bypass the constructor.
       const r = create(Realm.prototype);
@@ -92,9 +91,7 @@ export function buildChildRealm(unsafeRec, BaseRealm) {
       return r;
     }
 
-    static makeCompartment(options) {
-      options = Object(options); // todo: sanitize
-
+    static makeCompartment(options = {}) {
       // Bypass the constructor.
       const r = create(Realm.prototype);
       callAndWrapError(initCompartment, unsafeRec, r, options);

--- a/src/sourceParser.js
+++ b/src/sourceParser.js
@@ -96,3 +96,11 @@ export function rejectDangerousSources(s) {
   rejectImportExpressions(s);
   rejectSomeDirectEvalExpressions(s);
 }
+
+// Export a rewriter transform.
+export const rejectDangerousSourcesTransform = {
+  rewrite(rs) {
+    rejectDangerousSources(rs.src);
+    return rs;
+  }
+};

--- a/test/module/realmFacade.js
+++ b/test/module/realmFacade.js
@@ -155,7 +155,7 @@ test('buildChildRealm - Realm.makeRootRealm', t => {
 });
 
 test('buildChildRealm - Realm.makeCompartment', t => {
-  t.plan(4);
+  t.plan(5);
 
   sinon.spy(BaseRealm, 'initCompartment');
 
@@ -165,9 +165,10 @@ test('buildChildRealm - Realm.makeCompartment', t => {
   t.equals(BaseRealm.initCompartment.callCount, 1);
 
   const args = BaseRealm.initCompartment.getCall(0).args;
-  t.equals(args.length, 2);
+  t.equals(args.length, 3);
   t.equals(args[0], unsafeRec);
   t.ok(args[1] instanceof Realm);
+  t.deepEqual(args[2], {});
 
   BaseRealm.initCompartment.restore();
 });
@@ -193,13 +194,14 @@ test('buildChildRealm - realm.global', t => {
 });
 
 test('buildChildRealm - realm.evaluate', t => {
-  t.plan(6);
+  t.plan(7);
 
   const expectedResult = 123;
   sinon.stub(BaseRealm, 'realmEvaluate').callsFake(() => expectedResult);
 
   const source = 'abc';
   const endowments = {};
+  const options = {};
   const Realm = buildChildRealm(unsafeRec, BaseRealm);
   const compartment = Realm.makeCompartment();
   const actualResult = compartment.evaluate(source, endowments);
@@ -207,10 +209,11 @@ test('buildChildRealm - realm.evaluate', t => {
   t.equals(BaseRealm.realmEvaluate.callCount, 1);
 
   const args = BaseRealm.realmEvaluate.getCall(0).args;
-  t.equals(args.length, 3);
+  t.equals(args.length, 4);
   t.ok(args[0] instanceof Realm);
   t.equals(args[1], source);
   t.equals(args[2], endowments);
+  t.deepEqual(args[3], options);
 
   t.equals(actualResult, expectedResult);
 


### PR DESCRIPTION
Provide a more generalized rewrite/endow mechanism to allow for pluggable source transformations.

This moves the work of infix-bang and import/export rewrites to the realm-creating host instead of builtin functionality.