### PR TITLE
transforms: allow final initialization of Realm

### DIFF
--- a/src/realm.js
+++ b/src/realm.js
@@ -78,6 +78,14 @@ function createRealmRec(unsafeRec, transforms) {
   return realmRec;
 }
 
+// Initialize all the transforms for the new Realm.
+function initTransforms(r, transforms) {
+  if (!transforms) {
+    return;
+  }
+  transforms.forEach(transform => transform.init && transform.init(r));
+}
+
 /**
  * A root realm uses a fresh set of new intrinics. Here we first create
  * a new unsafe record, which inherits the shims. Then we proceed with
@@ -117,6 +125,8 @@ function initRootRealm(parentUnsafeRec, self, options) {
 
   // The realmRec acts as a private field on the realm instance.
   registerRealmRecForRealmInstance(self, realmRec);
+
+  initTransforms(self, transforms);
 }
 
 /**
@@ -130,6 +140,8 @@ function initCompartment(unsafeRec, self, options = {}) {
 
   // The realmRec acts as a private field on the realm instance.
   registerRealmRecForRealmInstance(self, realmRec);
+
+  initTransforms(self, options.transforms);
 }
 
 function getRealmGlobal(self) {

--- a/test/module/realm.js
+++ b/test/module/realm.js
@@ -4,5 +4,5 @@ import Realm from '../../src/realm';
 test('new Realm', t => {
   t.plan(1);
 
-  t.throws(() => new Realm(), TypeError, 'new Real() should throws');
+  t.throws(() => new Realm(), TypeError, 'new Realm() should throw');
 });

--- a/test/realm/test-transforms.js
+++ b/test/realm/test-transforms.js
@@ -1,0 +1,37 @@
+import test from 'tape';
+import Realm from '../../src/realm';
+
+test('init transforms', t => {
+  try {
+    for (const isRoot of [true, false]) {
+      const transforms = [
+        {
+          init(r) {
+            r.global.MyGlobal = r.evaluate(`(nick) => 'goodbye ' + nick`);
+            r.myFirstSymbol = 'foo';
+          }
+        },
+        {
+          init(r) {
+            r.mySymbol = 'hello';
+          }
+        },
+        {
+          init(r) {
+            r.global.MyGlobal = r.evaluate(`(nick) => 'hello ' + nick`);
+          }
+        }
+      ];
+      const r = isRoot
+        ? Realm.makeRootRealm({ transforms })
+        : Realm.makeCompartment({ transforms });
+      t.equal(r.evaluate(`MyGlobal('person')`), 'hello person');
+      t.equal(r.mySymbol, 'hello');
+      t.equal(r.myFirstSymbol, 'foo');
+    }
+  } catch (e) {
+    t.assert(false, e);
+  } finally {
+    t.end();
+  }
+});


### PR DESCRIPTION
This is useful when trying to override the realm's globals, for example.
