### PR TITLE
fix: reenable indirect eval

### DIFF
--- a/test/module/evaluators.js
+++ b/test/module/evaluators.js
@@ -127,7 +127,7 @@ test('createSafeEvaluatorWhichTakesEndowments - options.transforms', t => {
 });
 
 test('createSafeEvaluatorWhichTakesEndowments', t => {
-  t.plan(9);
+  t.plan(11);
 
   // Mimic repairFunctions.
   // eslint-disable-next-line no-proto
@@ -149,6 +149,9 @@ test('createSafeEvaluatorWhichTakesEndowments', t => {
 
   t.equal(safeEval('foo', endowments), 1);
   t.equal(safeEval('bar', endowments), 4);
+
+  t.equal(safeEval(`(1, eval)('foo')`, endowments), 1);
+  t.equal(safeEval(`(1, eval)('bar')`, endowments), 4);
 
   t.throws(() => safeEval('foo = 5', {}), TypeError);
   safeEval('bar = 6', {});


### PR DESCRIPTION
closes #25

The issue preventing indirect eval was that the scoped evaluator looks up `eval` on the proxy target, but it is not defined in either the safeGlobal, nor endowments.  This fix makes it work again (if it did before) but needs a careful review.
