### PR TITLE
fixing examples/simple.js due to new direct eval restrictions

### DIFF
--- a/examples/simple.js
+++ b/examples/simple.js
@@ -1,35 +1,6 @@
 /* global Realm */
 /* eslint-disable no-self-compare, no-console */
 
-// basic sanity check: they all should output true
-// Root realm
-const r1 = Realm.makeRootRealm();
-console.log(1.1, r1.evaluate('JSON'));
-console.log(1.2, r1.evaluate('JSON') !== JSON);
-console.log(1.3, r1.evaluate('JSON') === r1.evaluate('JSON'));
-console.log(1.4, r1.evaluate('JSON') === r1.evaluate('eval("JSON")'));
-console.log(1.5, r1.evaluate('eval instanceof Function'));
-
-// Root realm vs root realm
-const r2 = Realm.makeRootRealm();
-console.log(2.1, r2.evaluate('JSON'));
-console.log(2.2, r2.evaluate('JSON') !== JSON);
-console.log(2.3, r2.evaluate('JSON') === r2.evaluate('JSON'));
-console.log(2.4, r2.evaluate('JSON') === r2.evaluate('eval("JSON")'));
-console.log(2.5, r2.evaluate('eval instanceof Function'));
-console.log(2.6, r2.evaluate('JSON') !== r1.evaluate('JSON'));
-console.log(2.7, r2.evaluate('eval("JSON")') !== r1.evaluate('eval("JSON")'));
-
-// Compartment realm vs root realm
-const r3 = r1.global.Realm.makeCompartment();
-console.log(3.1, r3.evaluate('JSON'));
-console.log(3.2, r3.evaluate('JSON') !== JSON);
-console.log(3.3, r3.evaluate('JSON') === r3.evaluate('JSON'));
-console.log(3.4, r3.evaluate('JSON') === r3.evaluate('eval("JSON")'));
-console.log(3.5, r1.evaluate('eval instanceof Function'));
-console.log(3.6, r3.evaluate('JSON') === r1.evaluate('JSON'));
-console.log(3.7, r3.evaluate('eval("JSON")') === r1.evaluate('eval("JSON")'));
-
 const r = Realm.makeRootRealm();
 
 document.getElementById('run').addEventListener('click', () => {


### PR DESCRIPTION
the example was broken (not sure for how long) because it was using direct eval form on the sanity checks.

for now, I just removed the sanity checks since we now have proper tests. another alternative is to preserve the sanity checks but use indirect eval form instead of direct eval for those checks.