### PR TITLE
options.sloppyGlobals: object to receive REPL variable assigments

### DIFF
--- a/src/evaluators.js
+++ b/src/evaluators.js
@@ -68,10 +68,15 @@ function createScopedEvaluatorFactory(unsafeRec, constants) {
   `);
 }
 
-export function createSafeEvaluatorFactory(unsafeRec, safeGlobal, transforms) {
+export function createSafeEvaluatorFactory(
+  unsafeRec,
+  safeGlobal,
+  transforms,
+  sloppyGlobals
+) {
   const { unsafeFunction } = unsafeRec;
 
-  const scopeHandler = createScopeHandler(unsafeRec, safeGlobal);
+  const scopeHandler = createScopeHandler(unsafeRec, safeGlobal, sloppyGlobals);
   const constants = getOptimizableGlobals(safeGlobal);
   const scopedEvaluatorFactory = createScopedEvaluatorFactory(
     unsafeRec,

--- a/src/realm.js
+++ b/src/realm.js
@@ -50,7 +50,7 @@ function setDefaultBindings(safeGlobal, safeEval, safeFunction) {
   });
 }
 
-function createRealmRec(unsafeRec, transforms) {
+function createRealmRec(unsafeRec, transforms, sloppyGlobals) {
   const { sharedGlobalDescs, unsafeGlobal } = unsafeRec;
 
   const safeGlobal = create(unsafeGlobal.Object.prototype, sharedGlobalDescs);
@@ -58,7 +58,8 @@ function createRealmRec(unsafeRec, transforms) {
   const safeEvaluatorFactory = createSafeEvaluatorFactory(
     unsafeRec,
     safeGlobal,
-    transforms
+    transforms,
+    sloppyGlobals
   );
   const safeEval = createSafeEvaluator(safeEvaluatorFactory);
   const safeEvalWhichTakesEndowments = createSafeEvaluatorWhichTakesEndowments(
@@ -107,7 +108,7 @@ function initRootRealm(parentUnsafeRec, self, options) {
 
   // Creating the realmRec provides the global object, eval() and Function()
   // to the realm.
-  const realmRec = createRealmRec(unsafeRec, transforms);
+  const realmRec = createRealmRec(unsafeRec, transforms, options.sloppyGlobals);
 
   // Apply all shims in the new RootRealm. We don't do this for compartments.
   const { safeEvalWhichTakesEndowments } = realmRec;
@@ -126,7 +127,11 @@ function initRootRealm(parentUnsafeRec, self, options) {
 function initCompartment(unsafeRec, self, options = {}) {
   // note: 'self' is the instance of the Realm.
 
-  const realmRec = createRealmRec(unsafeRec, options.transforms);
+  const realmRec = createRealmRec(
+    unsafeRec,
+    options.transforms,
+    options.sloppyGlobals
+  );
 
   // The realmRec acts as a private field on the realm instance.
   registerRealmRecForRealmInstance(self, realmRec);

--- a/test/module/evaluators.js
+++ b/test/module/evaluators.js
@@ -76,7 +76,7 @@ test('createSafeEvaluator', t => {
   Function.__proto__.constructor.restore();
 });
 
-test('createSafeEvaluatorWhichTakesEndowments - options.sloppyGlobals', t => {
+test.only('createSafeEvaluatorWhichTakesEndowments - options.sloppyGlobals', t => {
   try {
     // Mimic repairFunctions.
     // eslint-disable-next-line no-proto
@@ -108,12 +108,14 @@ test('createSafeEvaluatorWhichTakesEndowments - options.sloppyGlobals', t => {
       ReferenceError,
       'no such sloppy global'
     );
+    t.assert(!('def' in sloppyGlobals), 'sloppy global does not yet exist');
     t.equal(
       safeEval('def = abc + 333', { abc: 123 }),
       456,
       'sloppy global assignment'
     );
     t.equal(safeEval('def', { abc: 123 }), 456, 'sloppy global persists');
+    t.equal(sloppyGlobals.def, 456, 'sloppy global uses our object');
   } catch (e) {
     t.isNot(e, e);
   } finally {

--- a/test/module/evaluators.js
+++ b/test/module/evaluators.js
@@ -76,6 +76,53 @@ test('createSafeEvaluator', t => {
   Function.__proto__.constructor.restore();
 });
 
+test('createSafeEvaluatorWhichTakesEndowments - options.sloppyGlobals', t => {
+  try {
+    // Mimic repairFunctions.
+    // eslint-disable-next-line no-proto
+    sinon.stub(Function.__proto__, 'constructor').callsFake(() => {
+      throw new TypeError();
+    });
+
+    const safeGlobal = Object.create(null, {
+      foo: { value: 1 },
+      bar: { value: 2, writable: true }
+    });
+
+    const realmTransforms = [];
+    const sloppyGlobals = {};
+
+    const safeEval = createSafeEvaluatorWhichTakesEndowments(
+      createSafeEvaluatorFactory(
+        unsafeRecord,
+        safeGlobal,
+        realmTransforms,
+        sloppyGlobals
+      )
+    );
+
+    // Evaluate normally.
+    t.equal(safeEval('abc', { abc: 123 }), 123, 'endowment eval');
+    t.throws(
+      () => safeEval('def', { abc: 123 }),
+      ReferenceError,
+      'no such sloppy global'
+    );
+    t.equal(
+      safeEval('def = abc + 333', { abc: 123 }),
+      456,
+      'sloppy global assignment'
+    );
+    t.equal(safeEval('def', { abc: 123 }), 456, 'sloppy global persists');
+  } catch (e) {
+    t.isNot(e, e);
+  } finally {
+    // eslint-disable-next-line no-proto
+    Function.__proto__.constructor.restore();
+    t.end();
+  }
+});
+
 test('createSafeEvaluatorWhichTakesEndowments - options.transforms', t => {
   t.plan(4);
 

--- a/test/module/utilities.js
+++ b/test/module/utilities.js
@@ -39,7 +39,7 @@ test('throwTantrum', t => {
     'please report internal shim error: foo'
   );
   t.equals(console.error.getCall(1).args[0], 'Error: bar');
-  t.ok(console.error.getCall(2).args[0].includes('at t.throws'));
+  t.ok(console.error.getCall(2).args[0].match(/\sat (Test|t)\.throws/));
 
   console.error.restore();
 });


### PR DESCRIPTION
This option designates the object that is used as a backing store
for assignments to names that aren't bound elsewhere.  This allows
the creation of realms and compartments that can share mutable global state
among separate evaluations.
