### PR TITLE
test/module/evaluators.js: remove test.only

### DIFF
--- a/test/module/evaluators.js
+++ b/test/module/evaluators.js
@@ -76,7 +76,7 @@ test('createSafeEvaluator', t => {
   Function.__proto__.constructor.restore();
 });
 
-test.only('createSafeEvaluatorWhichTakesEndowments - options.sloppyGlobals', t => {
+test('createSafeEvaluatorWhichTakesEndowments - options.sloppyGlobals', t => {
   try {
     // Mimic repairFunctions.
     // eslint-disable-next-line no-proto


### PR DESCRIPTION
This line escaped me during the sloppyGlobals merge.

It accidentally disabled most of the test suite.