### PR TITLE
Prepare package for publishing.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -957,16 +957,6 @@
         }
       }
     },
-    "cross-env": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-5.2.0.tgz",
-      "integrity": "sha512-jtdNFfFW1hB7sMhr/H6rW1Z45LFqyI431m3qU6bFXcQ3Eh7LtBuG3h74o7ohHZ3crrRkkqHlo4jYHFPcjroANg==",
-      "dev": true,
-      "requires": {
-        "cross-spawn": "^6.0.5",
-        "is-windows": "^1.0.0"
-      }
-    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",

--- a/package.json
+++ b/package.json
@@ -34,12 +34,11 @@
     "shim:coveralls": "nyc report --reporter=text-lcov | coveralls",
     "shim:build": "npm run shim:build:dev && npm run shim:build:prod",
     "shim:watch": "npm run shim:build:dev --watch",
-    "shim:build:dev": "cross-env NODE_ENV=development rollup -c rollup.config.js",
-    "shim:build:prod": "cross-env NODE_ENV=production rollup -c rollup.config.js"
+    "shim:build:dev": "rollup -c",
+    "shim:build:prod": "rollup -c --environment NODE_ENV:production"
   },
   "devDependencies": {
     "coveralls": "^3.0.3",
-    "cross-env": "^5.2.0",
     "eslint": "^5.15.3",
     "eslint-config-airbnb-base": "^13.1.0",
     "eslint-config-prettier": "^4.1.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,38 +1,48 @@
-import path from 'path';
 import minify from 'rollup-plugin-babel-minify';
 import stripCode from 'rollup-plugin-strip-code';
 
-const isProduction = process.env.NODE_ENV === 'production';
+export default () => {
+  const isProduction = process.env.NODE_ENV === 'production';
+  const minfix = isProduction ? '.min' : '';
 
-export default {
-  input: path.resolve('src/main.js'),
-  output: [
+  const output = [
     {
-      file: path.resolve(isProduction ? 'dist/realms-shim.umd.min.js' : 'dist/realms-shim.umd.js'),
+      file: `dist/realms-shim.umd${minfix}.js`,
       name: 'Realm',
       format: 'umd',
       sourcemap: true
     },
     {
-      file: 'dist/realms-shim.esm.js',
+      file: `dist/realms-shim.esm${minfix}.js`,
       format: 'esm',
       sourcemap: true
-    },
-    {
-      file: 'dist/realms-shim.cjs.js',
-      format: 'cjs',
-      sourcemap: true
     }
-  ],
-  plugins: [
+  ];
+
+  const plugins = [
     stripCode({
       start_comment: 'START_TESTS_ONLY',
       end_comment: 'END_TESTS_ONLY'
-    }),
-    isProduction
-      ? minify({
-          comments: false
-        })
-      : {}
-  ]
-};
+    })
+  ];
+
+  if (isProduction) {
+    plugins.push(
+      minify({
+        comments: false
+      })
+    );
+  } else {
+    output.push({
+      file: 'dist/realms-shim.cjs.js',
+      format: 'cjs',
+      sourcemap: true
+    });
+  }
+
+  return {
+    input: 'src/main.js',
+    output,
+    plugins
+  };
+}


### PR DESCRIPTION
This PR addresses #29 by tweaking the build script to generate unminified CJS output. The rest of the package is in great shape for publishing so nothing needed there. I tested what the published package would generate with `npm pack`.

At the moment before publishing you should run `npm run shim:build` and then `npm publish`. For the publishing account used I assume it would be an Agoric user _(number of accounts with publish access should be limited as they each are a security point)_. 

You should have 2factor authentication enabled for login and writes. See https://docs.npmjs.com/about-two-factor-authentication#authorization-and-writes. Besides the command-line way to enable 2factor authentication there is also a web UI way through the [npm site](https://www.npmjs.com/) once logged in.

#### Optional enhancements:
This PR could be enhanced to make the `package.json` private and only flipped to publish during a `npm run shim:publish` script if desired.