### PR TITLE
Configurable transforms

### DIFF
--- a/src/evaluators.js
+++ b/src/evaluators.js
@@ -87,11 +87,12 @@ export function createSafeEvaluatorFactory(
     const localTransforms = options.transforms || [];
     const realmTransforms = transforms || [];
 
-    const mandatoryTransforms = [rejectDangerousSourcesTransform];
+    const defaultTransforms =
+      realmTransforms.length > 0 ? [] : [rejectDangerousSourcesTransform];
     const allTransforms = [
       ...localTransforms,
       ...realmTransforms,
-      ...mandatoryTransforms
+      ...defaultTransforms
     ];
 
     // We use the the concise method syntax to create an eval without a

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,1 @@
 export { default } from './realm';
-export {
-  rejectSomeDirectEvalExpressionsTransform,
-  rejectHtmlCommentsTransform,
-  rejectImportExpressionsTransform
-} from './sourceParser';

--- a/src/main.js
+++ b/src/main.js
@@ -1,1 +1,6 @@
 export { default } from './realm';
+export {
+  rejectSomeDirectEvalExpressionsTransform,
+  rejectHtmlCommentsTransform,
+  rejectImportExpressionsTransform
+} from './sourceParser';

--- a/src/sourceParser.js
+++ b/src/sourceParser.js
@@ -115,7 +115,6 @@ export const rejectSomeDirectEvalExpressionsTransform = {
   }
 };
 
-
 export function rejectDangerousSources(s) {
   rejectHtmlComments(s);
   rejectImportExpressions(s);

--- a/src/sourceParser.js
+++ b/src/sourceParser.js
@@ -28,6 +28,14 @@ function rejectHtmlComments(s) {
   }
 }
 
+// Export a rewriter transform.
+export const rejectHtmlCommentsTransform = {
+  rewrite(rs) {
+    rejectHtmlComments(rs.src);
+    return rs;
+  }
+};
+
 // The proposed dynamic import expression is the only syntax currently
 // proposed, that can appear in non-module JavaScript code, that
 // enables direct access to the outside world that cannot be
@@ -62,6 +70,14 @@ function rejectImportExpressions(s) {
   }
 }
 
+// Export a rewriter transform.
+export const rejectImportExpressionsTransform = {
+  rewrite(rs) {
+    rejectImportExpressions(rs.src);
+    return rs;
+  }
+};
+
 // The shim cannot correctly emulate a direct eval as explained at
 // https://github.com/Agoric/realms-shim/issues/12
 // Without rejecting apparent direct eval syntax, we would
@@ -90,6 +106,15 @@ function rejectSomeDirectEvalExpressions(s) {
     );
   }
 }
+
+// Export a rewriter transform.
+export const rejectSomeDirectEvalExpressionsTransform = {
+  rewrite(rs) {
+    rejectSomeDirectEvalExpressions(rs.src);
+    return rs;
+  }
+};
+
 
 export function rejectDangerousSources(s) {
   rejectHtmlComments(s);


### PR DESCRIPTION
This PR addresses https://github.com/Agoric/realms-shim/issues/34 and adds configurable options for internal source parsers used by realm-shim.  

*rejectImportExpressions: true|false* : default true, use the `rejectImportExpressions` transformer
*rejectHtmlComments: true|false* : default true, use the `rejectHtmlComments` transformer
*rejectSomeDirectEvalExpressions: true|false* : default true, use the  `rejectSomeDirectEvalExpressions` transformer

Set flags to `false` to selectively disable mandatory transformers. By default all transformer are enabled.

```
// a compartment which has only rejectHtmlComments enabled
Realm.createCompartment({ rejectImportExpressions: false, rejectSomeDirectEvalExpressions: false }) 

// a root realm having only rejectImportExpressions and htmlComments enabled
Realm.makeRootRealm({ rejectSomeDirectEvalExpressions: false })
```
