### PR TITLE
allow configurable Realm transforms

### DIFF
--- a/examples/simple.js
+++ b/examples/simple.js
@@ -1,7 +1,7 @@
 /* global Realm */
 /* eslint-disable no-self-compare, no-console */
 
-const r = Realm.makeRootRealm();
+const r = Realm.default.makeRootRealm();
 
 document.getElementById('run').addEventListener('click', () => {
   const sourceText = document.getElementById('sourceText').value;

--- a/src/main.js
+++ b/src/main.js
@@ -1,1 +1,1 @@
-export { default } from './realm';
+export { default, makeRealmClass } from './realm';

--- a/src/sourceParser.js
+++ b/src/sourceParser.js
@@ -18,7 +18,7 @@
 // rejection by the overly eager rejectDangerousSources.
 const htmlCommentPattern = new RegExp(`(?:${'<'}!--|--${'>'})`);
 
-function rejectHtmlComments(s) {
+export function rejectHtmlComments(s) {
   const index = s.search(htmlCommentPattern);
   if (index !== -1) {
     const linenum = s.slice(0, index).split('\n').length; // more or less
@@ -27,6 +27,14 @@ function rejectHtmlComments(s) {
     );
   }
 }
+
+// Export a rewriter transform.
+export const rejectHtmlCommentsTransform = {
+  rewrite(rs) {
+    rejectHtmlComments(rs.src);
+    return rs;
+  }
+};
 
 // The proposed dynamic import expression is the only syntax currently
 // proposed, that can appear in non-module JavaScript code, that
@@ -50,9 +58,9 @@ function rejectHtmlComments(s) {
 // something like that from something like importnotreally('power.js') which
 // is perfectly safe.
 
-const importPattern = /\bimport\s*(?:\(|\/[/*])/;
+const importPattern = /\bimport\s*(?:\(|\/[/*]|<!--|-->)/;
 
-function rejectImportExpressions(s) {
+export function rejectImportExpressions(s) {
   const index = s.search(importPattern);
   if (index !== -1) {
     const linenum = s.slice(0, index).split('\n').length; // more or less
@@ -61,6 +69,14 @@ function rejectImportExpressions(s) {
     );
   }
 }
+
+// Export a rewriter transform.
+export const rejectImportExpressionsTransform = {
+  rewrite(rs) {
+    rejectImportExpressions(rs.src);
+    return rs;
+  }
+};
 
 // The shim cannot correctly emulate a direct eval as explained at
 // https://github.com/Agoric/realms-shim/issues/12
@@ -79,9 +95,9 @@ function rejectImportExpressions(s) {
 // occurrences, not malicious one. In particular, `(eval)(...)` is
 // direct eval syntax that would not be caught by the following regexp.
 
-const someDirectEvalPattern = /\beval\s*(?:\(|\/[/*])/;
+const someDirectEvalPattern = /\beval\s*(?:\(|\/[/*]|<!--|-->)/;
 
-function rejectSomeDirectEvalExpressions(s) {
+export function rejectSomeDirectEvalExpressions(s) {
   const index = s.search(someDirectEvalPattern);
   if (index !== -1) {
     const linenum = s.slice(0, index).split('\n').length; // more or less
@@ -91,16 +107,10 @@ function rejectSomeDirectEvalExpressions(s) {
   }
 }
 
-export function rejectDangerousSources(s) {
-  rejectHtmlComments(s);
-  rejectImportExpressions(s);
-  rejectSomeDirectEvalExpressions(s);
-}
-
 // Export a rewriter transform.
-export const rejectDangerousSourcesTransform = {
+export const rejectSomeDirectEvalExpressionsTransform = {
   rewrite(rs) {
-    rejectDangerousSources(rs.src);
+    rejectSomeDirectEvalExpressions(rs.src);
     return rs;
   }
 };

--- a/test/module/realm.js
+++ b/test/module/realm.js
@@ -4,5 +4,5 @@ import Realm from '../../src/realm';
 test('new Realm', t => {
   t.plan(1);
 
-  t.throws(() => new Realm(), TypeError, 'new Real() should throws');
+  t.throws(() => new Realm(), TypeError, 'new Realm() should throws');
 });

--- a/test/module/realmFacade.js
+++ b/test/module/realmFacade.js
@@ -168,7 +168,13 @@ test('buildChildRealm - Realm.makeCompartment', t => {
   t.equals(args.length, 3);
   t.equals(args[0], unsafeRec);
   t.ok(args[1] instanceof Realm);
-  t.deepEqual(args[2], {});
+  t.deepEqual(args[2], {
+    sourceParserFlags: {
+      rejectHtmlComments: undefined,
+      rejectImportExpressions: undefined,
+      rejectSomeDirectEvalExpressions: undefined
+    }
+  });
 
   BaseRealm.initCompartment.restore();
 });

--- a/test/realm/test-direct-eval.js
+++ b/test/realm/test-direct-eval.js
@@ -1,6 +1,6 @@
 import test from 'tape';
 import Realm from '../../src/realm';
-import { rejectDangerousSources } from '../../src/sourceParser';
+import { rejectSomeDirectEvalExpressions } from '../../src/sourceParser';
 
 const safe = `const a = 1`;
 
@@ -40,31 +40,47 @@ eval('a')
 eval('b')`;
 
 test('no-eval-expression regexp', t => {
-  t.equal(rejectDangerousSources(safe), undefined, 'safe');
-  t.equal(rejectDangerousSources(safe2), undefined, 'safe2');
-  t.equal(rejectDangerousSources(safe3), undefined, 'safe3');
-  t.equal(rejectDangerousSources(bogus), undefined, 'bogus');
-  t.throws(() => rejectDangerousSources(obvious), SyntaxError, 'obvious');
-  t.throws(() => rejectDangerousSources(whitespace), SyntaxError, 'whitespace');
-  t.throws(() => rejectDangerousSources(comment), SyntaxError, 'comment');
+  t.equal(rejectSomeDirectEvalExpressions(safe), undefined, 'safe');
+  t.equal(rejectSomeDirectEvalExpressions(safe2), undefined, 'safe2');
+  t.equal(rejectSomeDirectEvalExpressions(safe3), undefined, 'safe3');
+  t.equal(rejectSomeDirectEvalExpressions(bogus), undefined, 'bogus');
   t.throws(
-    () => rejectDangerousSources(doubleSlashComment),
+    () => rejectSomeDirectEvalExpressions(obvious),
+    SyntaxError,
+    'obvious'
+  );
+  t.throws(
+    () => rejectSomeDirectEvalExpressions(whitespace),
+    SyntaxError,
+    'whitespace'
+  );
+  t.throws(
+    () => rejectSomeDirectEvalExpressions(comment),
+    SyntaxError,
+    'comment'
+  );
+  t.throws(
+    () => rejectSomeDirectEvalExpressions(doubleSlashComment),
     SyntaxError,
     'doubleSlashComment'
   );
   t.throws(
-    () => rejectDangerousSources(htmlOpenComment),
+    () => rejectSomeDirectEvalExpressions(htmlOpenComment),
     SyntaxError,
     'htmlOpenComment'
   );
   t.throws(
-    () => rejectDangerousSources(htmlCloseComment),
+    () => rejectSomeDirectEvalExpressions(htmlCloseComment),
     SyntaxError,
     'htmlCloseComment'
   );
-  t.throws(() => rejectDangerousSources(newline), SyntaxError, 'newline');
   t.throws(
-    () => rejectDangerousSources(multiline),
+    () => rejectSomeDirectEvalExpressions(newline),
+    SyntaxError,
+    'newline'
+  );
+  t.throws(
+    () => rejectSomeDirectEvalExpressions(multiline),
     /SyntaxError: possible direct eval expression rejected around line 2/,
     'multiline'
   );

--- a/test/realm/test-html-comment.js
+++ b/test/realm/test-html-comment.js
@@ -1,6 +1,6 @@
 import test from 'tape';
 import Realm from '../../src/realm';
-import { rejectDangerousSources } from '../../src/sourceParser';
+import { rejectHtmlComments } from '../../src/sourceParser';
 
 // We break up the following literal strings so that an apparent html
 // comment does not appear in this file. Thus, we avoid rejection by
@@ -14,13 +14,13 @@ const htmlCloseComment = `const a = foo --${'>'} hah
 
 test('no-html-comment-expression regexp', t => {
   t.throws(
-    () => rejectDangerousSources(htmlOpenComment),
+    () => rejectHtmlComments(htmlOpenComment),
     SyntaxError,
     'htmlOpenComment'
   );
 
   t.throws(
-    () => rejectDangerousSources(htmlCloseComment),
+    () => rejectHtmlComments(htmlCloseComment),
     SyntaxError,
     'htmlCloseComment'
   );

--- a/test/realm/test-import-expression.js
+++ b/test/realm/test-import-expression.js
@@ -1,6 +1,6 @@
 import test from 'tape';
 import Realm from '../../src/realm';
-import { rejectDangerousSources } from '../../src/sourceParser';
+import { rejectImportExpressions } from '../../src/sourceParser';
 
 function codepointIsSyntacticWhitespace(i) {
   const c = String.fromCodePoint(i);
@@ -78,30 +78,34 @@ test('no-import-expression regexp', t => {
   // 'tape -r esm ./shim/test/**/*.js') sees the 'import' statements and
   // rewrites them.
 
-  t.equal(rejectDangerousSources(safe), undefined, 'safe');
-  t.equal(rejectDangerousSources(safe2), undefined, 'safe2');
-  t.equal(rejectDangerousSources(safe3), undefined, 'safe3');
-  t.throws(() => rejectDangerousSources(obvious), SyntaxError, 'obvious');
-  t.throws(() => rejectDangerousSources(whitespace), SyntaxError, 'whitespace');
-  t.throws(() => rejectDangerousSources(comment), SyntaxError, 'comment');
+  t.equal(rejectImportExpressions(safe), undefined, 'safe');
+  t.equal(rejectImportExpressions(safe2), undefined, 'safe2');
+  t.equal(rejectImportExpressions(safe3), undefined, 'safe3');
+  t.throws(() => rejectImportExpressions(obvious), SyntaxError, 'obvious');
   t.throws(
-    () => rejectDangerousSources(doubleSlashComment),
+    () => rejectImportExpressions(whitespace),
+    SyntaxError,
+    'whitespace'
+  );
+  t.throws(() => rejectImportExpressions(comment), SyntaxError, 'comment');
+  t.throws(
+    () => rejectImportExpressions(doubleSlashComment),
     SyntaxError,
     'doubleSlashComment'
   );
   t.throws(
-    () => rejectDangerousSources(htmlOpenComment),
+    () => rejectImportExpressions(htmlOpenComment),
     SyntaxError,
     'htmlOpenComment'
   );
   t.throws(
-    () => rejectDangerousSources(htmlCloseComment),
+    () => rejectImportExpressions(htmlCloseComment),
     SyntaxError,
     'htmlCloseComment'
   );
-  t.throws(() => rejectDangerousSources(newline), SyntaxError, 'newline');
+  t.throws(() => rejectImportExpressions(newline), SyntaxError, 'newline');
   t.throws(
-    () => rejectDangerousSources(multiline),
+    () => rejectImportExpressions(multiline),
     /SyntaxError: possible import expression rejected around line 2/,
     'multiline'
   );


### PR DESCRIPTION
This PR addresses https://github.com/Agoric/realms-shim/issues/34 and adds configurable options for internal source parsers used by realm-shim.  

*rejectImportExpressions: true|false* : default true, use the `rejectImportExpressions` transformer
*rejectHtmlComments: true|false* : default true, use the `rejectHtmlComments` transformer
*rejectSomeDirectEvalExpressions: true|false* : default true, use the  `rejectSomeDirectEvalExpressions` transformer

Set flags to `false` to selectively disable mandatory transformers. By default all transformer are enabled.

```
// a compartment which has only rejectHtmlComments enabled
Realm.createCompartment({ rejectImportExpressions: false, rejectSomeDirectEvalExpressions: false }) 

// a root realm having only rejectImportExpressions and htmlComments enabled
Realm.makeRootRealm({ rejectSomeDirectEvalExpressions: false })
```

Edit:

Updated code to export a factory since this seems to be more in line with the discussion on the referenced issue:
```
// configure a primal ream with rejectImportExpressions set to false
// all child realms and their children will inherit this setting
const Realm = factory({rejectImportExpressions: false})

// inherits rejectImportExpressions = false
const r = Realm.makeRootRealm(); 

 // inherits rejectImportExpressions = false
const c = Realm.makeCompartment();

```
