### PR TITLE
repairFunctions: use globalEval binding to placate rollup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "realms-shim",
-  "version": "1.1.0",
+  "version": "1.1.1-dev.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "realms-shim",
-  "version": "1.1.0",
+  "version": "1.1.1-dev.0",
   "description": "Spec-compliant shim for Realms TC39 Proposal",
   "main": "dist/realms-shim.cjs.js",
   "module": "dist/realms-shim.esm.js",

--- a/src/repair/functions.js
+++ b/src/repair/functions.js
@@ -18,6 +18,7 @@
  */
 
 // todo: this file should be moved out to a separate repo and npm module.
+const globalEval = eval;
 export function repairFunctions() {
   const { defineProperties, getPrototypeOf, setPrototypeOf } = Object;
 
@@ -34,7 +35,7 @@ export function repairFunctions() {
     let FunctionInstance;
     try {
       // eslint-disable-next-line no-new-func
-      FunctionInstance = (0, eval)(declaration);
+      FunctionInstance = globalEval(declaration);
     } catch (e) {
       if (e instanceof SyntaxError) {
         // Prevent failure on platforms where async and/or generators

--- a/src/unsafeRec.js
+++ b/src/unsafeRec.js
@@ -94,7 +94,7 @@ const repairAccessorsShim = cleanupSource(
   `"use strict"; (${repairAccessors})();`
 );
 const repairFunctionsShim = cleanupSource(
-  `"use strict"; (${repairFunctions})();`
+  `"use strict"; const globalEval = eval; (${repairFunctions})();`
 );
 
 // Create a new unsafeRec from a brand new context, with new intrinsics and a


### PR DESCRIPTION
rollup is apparently allergic to the `(1, eval)(...)` trick to
avoid direct eval.  Binding eval to a different name is the only
way it supports usage without mangling.

This doesn't cause a failure of our tests, but when something
(like SES) imports `realms-shim`, the `repairFunctions` fails,
as rollup has rewritten `(1, eval)(...)` to something like
`(1, _f4f.e)(...)`.