### PR TITLE
Refactor evaluation stringified functions

### DIFF
--- a/src/callAndWrapError.js
+++ b/src/callAndWrapError.js
@@ -89,9 +89,6 @@ function buildCallAndWrapError() {
   return callAndWrapError;
 }
 
-const buildCallAndWrapErrorString = safeStringifyFunction(
+export const buildCallAndWrapErrorString = safeStringifyFunction(
   buildCallAndWrapError
 );
-export function createCallAndWrapError(unsafeEval) {
-  return unsafeEval(buildCallAndWrapErrorString)();
-}

--- a/src/childRealm.js
+++ b/src/childRealm.js
@@ -84,23 +84,4 @@ export function buildChildRealm(unsafeRec, BaseRealm) {
 // The parentheses means we don't bind the 'buildChildRealm' name inside the
 // child's namespace. this would accept an anonymous function declaration.
 // function expression (not a declaration) so it has a completion value.
-const buildChildRealmString = safeStringifyFunction(buildChildRealm);
-
-export function createRealmFacade(unsafeRec, BaseRealm) {
-  const { unsafeEval } = unsafeRec;
-  // The BaseRealm is the Realm class created by
-  // the shim. It's only valid for the context where
-  // it was parsed.
-
-  // The Realm facade is a lightweight class built in the
-  // context a different context, that provide a fully
-  // functional Realm class using the intrisics
-  // of that context.
-
-  // This process is simplified because all methods
-  // and properties on a realm instance already return
-  // values using the intrinsics of the realm's context.
-
-  // Invoke the BaseRealm constructor with Realm as the prototype.
-  return unsafeEval(buildChildRealmString)(unsafeRec, BaseRealm);
-}
+export const buildChildRealmString = safeStringifyFunction(buildChildRealm);

--- a/src/realm.js
+++ b/src/realm.js
@@ -1,4 +1,4 @@
-import { createRealmFacade, buildChildRealm } from './realmFacade';
+import { buildChildRealm, buildChildRealmString } from './childRealm';
 import { createNewUnsafeRec, createCurrentUnsafeRec } from './unsafeRec';
 import {
   createSafeEvaluatorFactory,
@@ -95,9 +95,13 @@ function initRootRealm(parentUnsafeRec, self, options) {
 
   // The unsafe record is created already repaired.
   const unsafeRec = createNewUnsafeRec(allShims);
+  const { unsafeEval } = unsafeRec;
 
-  // eslint-disable-next-line no-use-before-define
-  const Realm = createRealmFacade(unsafeRec, BaseRealm);
+  const Realm = unsafeEval(buildChildRealmString)(
+    unsafeRec,
+    // eslint-disable-next-line no-use-before-define
+    BaseRealm
+  );
 
   // Add a Realm descriptor to sharedGlobalDescs, so it can be defined onto the
   // safeGlobal like the rest of the globals.

--- a/src/safeEval.js
+++ b/src/safeEval.js
@@ -35,8 +35,4 @@ function buildSafeEval(unsafeRec, safeEvalOperation) {
 
   return safeEval;
 }
-const buildSafeEvalString = safeStringifyFunction(buildSafeEval);
-export function createSafeEval(unsafeRec, safeEvalOperation) {
-  const { unsafeEval } = unsafeRec;
-  return unsafeEval(buildSafeEvalString)(unsafeRec, safeEvalOperation);
-}
+export const buildSafeEvalString = safeStringifyFunction(buildSafeEval);

--- a/src/safeFunction.js
+++ b/src/safeFunction.js
@@ -30,8 +30,4 @@ function buildSafeFunction(unsafeRec, safeFunctionOperation) {
 
   return safeFunction;
 }
-const buildSafeFunctionString = safeStringifyFunction(buildSafeFunction);
-export function createSafeFunction(unsafeRec, safeFunctionOperation) {
-  const { unsafeEval } = unsafeRec;
-  return unsafeEval(buildSafeFunctionString)(unsafeRec, safeFunctionOperation);
-}
+export const buildSafeFunctionString = safeStringifyFunction(buildSafeFunction);

--- a/src/scopeHandler.js
+++ b/src/scopeHandler.js
@@ -159,18 +159,4 @@ export function buildScopeHandler(
   };
 }
 
-const buildScopeHandlerString = safeStringifyFunction(buildScopeHandler);
-export function createScopeHandler(
-  unsafeRec,
-  safeGlobal,
-  endowments,
-  sloppyGlobals
-) {
-  const { unsafeEval } = unsafeRec;
-  return unsafeEval(buildScopeHandlerString)(
-    unsafeRec,
-    safeGlobal,
-    endowments,
-    sloppyGlobals
-  );
-}
+export const buildScopeHandlerString = safeStringifyFunction(buildScopeHandler);

--- a/test/module/evaluators.js
+++ b/test/module/evaluators.js
@@ -37,7 +37,7 @@ test('createSafeEvaluator', t => {
     createSafeEvaluatorFactory(unsafeRec, safeGlobal)()
   );
 
-  t.equal(safeEval('debugger; foo'), 1);
+  t.equal(safeEval('foo'), 1);
   t.equal(safeEval('bar'), 2);
   t.throws(() => safeEval('none'), ReferenceError);
   t.equal(safeEval('this.foo'), 1);

--- a/test/realm/leak-unsafe-eval.js
+++ b/test/realm/leak-unsafe-eval.js
@@ -1,8 +1,12 @@
 import test from 'tape';
+import sinon from 'sinon';
 import Realm from '../../src/realm';
 
 test('HostException in eval revokes unsafeEval', t => {
   t.plan(2);
+
+  // Prevent output
+  sinon.stub(console, 'error').callsFake();
 
   const r = Realm.makeCompartment();
 
@@ -32,10 +36,16 @@ test('HostException in eval revokes unsafeEval', t => {
 
   t.notOk(evalToString.includes('native code'), "should not be parent's eval");
   t.ok(evalToString.includes('shim code'), "should be realm's eval");
+
+  // eslint-disable-next-line no-console
+  console.error.restore();
 });
 
 test('HostException in Function revokes unsafeEval', t => {
   t.plan(2);
+
+  // Prevent output
+  sinon.stub(console, 'error').callsFake();
 
   const r = Realm.makeCompartment();
 
@@ -65,4 +75,7 @@ test('HostException in Function revokes unsafeEval', t => {
 
   t.notOk(evalToString.includes('native code'), "should not be parent's eval");
   t.ok(evalToString.includes('shim code'), "should be realm's eval");
+
+  // eslint-disable-next-line no-console
+  console.error.restore();
 });


### PR DESCRIPTION
- Remove module name suffix *Facade
- Use realmRec.unsafeEval directly
- Reduce impact of esm in tests by capturing eval
- Remove console output from OOM tests.