### PR TITLE
Allow shims to mutate all globals with options.configurableGlobals

### DIFF
--- a/src/realm.js
+++ b/src/realm.js
@@ -90,11 +90,16 @@ function initRootRealm(parentUnsafeRec, self, options) {
 
   // todo: investigate attacks via Array.species
   // todo: this accepts newShims='string', but it should reject that
-  const { shims: newShims, transforms, sloppyGlobals } = options;
+  const {
+    shims: newShims,
+    transforms,
+    sloppyGlobals,
+    configurableGlobals
+  } = options;
   const allShims = arrayConcat(parentUnsafeRec.allShims, newShims);
 
   // The unsafe record is created already repaired.
-  const unsafeRec = createNewUnsafeRec(allShims);
+  const unsafeRec = createNewUnsafeRec(allShims, configurableGlobals);
   const { unsafeEval } = unsafeRec;
 
   const Realm = unsafeEval(buildChildRealmString)(

--- a/src/stdlib.js
+++ b/src/stdlib.js
@@ -99,7 +99,10 @@ const unstableGlobalPropertyNames = [
   'Intl'
 ];
 
-export function getSharedGlobalDescs(unsafeGlobal) {
+export function getSharedGlobalDescs(
+  unsafeGlobal,
+  configurableGlobals = false
+) {
   const descriptors = {};
 
   function describe(names, writable, enumerable, configurable) {
@@ -124,14 +127,15 @@ export function getSharedGlobalDescs(unsafeGlobal) {
     }
   }
 
-  describe(frozenGlobalPropertyNames, false, false, false);
-  // The following is correct but expensive.
-  // describe(stableGlobalPropertyNames, true, false, true);
-  // Instead, for now, we let these get optimized.
-  //
-  // TODO: We should provide an option to turn this optimization off,
-  // by feeding "true, false, true" here instead.
-  describe(stableGlobalPropertyNames, false, false, false);
+  if (configurableGlobals) {
+    describe(frozenGlobalPropertyNames, true, false, true);
+    // The following is correct but expensive.
+    describe(stableGlobalPropertyNames, true, false, true);
+  } else {
+    // Instead, for now, we let these get optimized.
+    describe(frozenGlobalPropertyNames, false, false, false);
+    describe(stableGlobalPropertyNames, false, false, false);
+  }
   // These we keep replaceable and removable, because we expect
   // others, e.g., SES, may want to do so.
   describe(unstableGlobalPropertyNames, true, false, true);

--- a/src/unsafeRec.js
+++ b/src/unsafeRec.js
@@ -79,8 +79,15 @@ const getNewUnsafeGlobal = () => {
 // tied to a set of intrinsics, aka the "undeniables". If it were possible to
 // mix-and-match them from different contexts, that would enable some
 // attacks.
-function createUnsafeRec(unsafeGlobal, allShims = []) {
-  const sharedGlobalDescs = getSharedGlobalDescs(unsafeGlobal);
+function createUnsafeRec(
+  unsafeGlobal,
+  allShims = [],
+  configurableGlobals = false
+) {
+  const sharedGlobalDescs = getSharedGlobalDescs(
+    unsafeGlobal,
+    configurableGlobals
+  );
 
   const unsafeEval = unsafeGlobal.eval;
   const unsafeFunction = unsafeGlobal.Function;
@@ -101,9 +108,13 @@ const repairFunctionsString = safeStringifyFunction(repairFunctions);
 
 // Create a new unsafeRec from a brand new context, with new intrinsics and a
 // new global object
-export function createNewUnsafeRec(allShims) {
+export function createNewUnsafeRec(allShims, configurableGlobals = false) {
   const unsafeGlobal = getNewUnsafeGlobal();
-  const unsafeRec = createUnsafeRec(unsafeGlobal, allShims);
+  const unsafeRec = createUnsafeRec(
+    unsafeGlobal,
+    allShims,
+    configurableGlobals
+  );
   const { unsafeEval } = unsafeRec;
   unsafeEval(repairAccessorsString)();
   unsafeEval(repairFunctionsString)();

--- a/test/realm/test-shims.js
+++ b/test/realm/test-shims.js
@@ -56,3 +56,34 @@ test('shims: inherited shims', t => {
 
   t.end();
 });
+
+test('shims: configurableGlobals', t => {
+  const shim = `(() => { try { this.Array = 999; } catch (e) {} })()`;
+
+  const r1 = Realm.makeRootRealm({ shims: [shim] });
+  t.notEqual(r1.global.Array, 999, 'optimized stable globals freeze Array');
+
+  const r2 = Realm.makeRootRealm({
+    shims: [shim],
+    configurableGlobals: true
+  });
+  t.equal(
+    r2.global.Array,
+    999,
+    'configurable stable globals allow Array mutation'
+  );
+
+  const c2 = r2.evaluate(`Realm.makeCompartment()`);
+  // FIXME: This call should be unnecessary.
+  Object.defineProperties(
+    c2.global,
+    Object.getOwnPropertyDescriptors(r2.global)
+  );
+  t.equal(
+    c2.global.Array,
+    999,
+    'configurable stable globals descend to Compartment'
+  );
+
+  t.end();
+});


### PR DESCRIPTION
This feature fixes a TODO that said the fast freezing of globals
that are generally "stable" is for performance, but isn't totally
correct.

The test case shows how to use it.

I've run into problems trying to provide a wrapper for all globals
from within a shim.  Notably, it was impossible to replace Array,
Object, and other functions in the global namespace because they
are frozen.