### PR TITLE
Don't explode on JSDoc import expressions

### DIFF
--- a/src/sourceParser.js
+++ b/src/sourceParser.js
@@ -59,22 +59,29 @@ const importPattern = /\bimport\s*(?:\(|\/[/*])/;
 // (import expressions cannot be the start of an object literal,
 // nor can decorators adorn blocks).
 //
-// Also note that the dollar at the end matches only the end of string.
+// Also note that the dollar at the end matches only the end of string,
+// since the 's' modifier is given.
 const allowedImportPrefix = /@[a-z]+ +\{$/s;
 
 function rejectImportExpressions(s) {
   let index = 0;
   for (;;) {
+    // Find the next `import` string in the source.
     const nextMatch = s.slice(index).search(importPattern);
     if (nextMatch === -1) {
+      // Not found, the source is okay.
       return;
     }
+    // Advance our index to the beginning of `import`.
     index += nextMatch;
+    // Take the source up to the match, and see if
+    // it ends in the allowed prefix.
     if (s.slice(0, index).match(allowedImportPrefix)) {
-      // Move the search one character forward.
+      // Move the search one character forward, and go again.
       index += 1;
       continue;
     }
+    // It doesn't end in the allowed prefix, so reject the source entirely.
     const linenum = s.slice(0, index).split('\n').length; // more or less
     throw new SyntaxError(
       `possible import expression rejected around line ${linenum}`

--- a/src/sourceParser.js
+++ b/src/sourceParser.js
@@ -64,7 +64,7 @@ const allowedImportPrefix = /@[a-z]+ +\{$/s;
 
 function rejectImportExpressions(s) {
   let index = 0;
-  while (true) {
+  for (;;) {
     const nextMatch = s.slice(index).search(importPattern);
     if (nextMatch === -1) {
       return;

--- a/test/module/evaluators.js
+++ b/test/module/evaluators.js
@@ -72,6 +72,8 @@ test('createSafeEvaluator', t => {
   t.equal(safeEval('this.bar'), 10);
   t.equal(safeEval('this.none'), 11);
 
+  t.equal(safeEval(`(1,eval)('123')`), 123, 'indirect eval');
+
   // eslint-disable-next-line no-proto
   Function.__proto__.constructor.restore();
 });

--- a/test/module/evaluators.js
+++ b/test/module/evaluators.js
@@ -72,8 +72,6 @@ test('createSafeEvaluator', t => {
   t.equal(safeEval('this.bar'), 10);
   t.equal(safeEval('this.none'), 11);
 
-  t.equal(safeEval(`(1,eval)('123')`), 123, 'indirect eval');
-
   // eslint-disable-next-line no-proto
   Function.__proto__.constructor.restore();
 });

--- a/test/realm/test-import-expression.js
+++ b/test/realm/test-import-expression.js
@@ -181,11 +181,7 @@ test('reject import expressions in Function', t => {
   t.throws(() => r.evaluate(wrap(obvious)), SyntaxError, 'obvious');
   t.throws(() => r.evaluate(wrap(whitespace)), SyntaxError, 'whitespace');
   t.throws(() => r.evaluate(wrap(comment)), SyntaxError, 'comment');
-  t.throws(
-    () => r.evaluate(wrap(evilAfterSafe)),
-    SyntaxError,
-    'evilAfterSafe'
-  );
+  t.throws(() => r.evaluate(wrap(evilAfterSafe)), SyntaxError, 'evilAfterSafe');
   t.throws(
     () => r.evaluate(wrap(doubleSlashComment)),
     SyntaxError,

--- a/test/realm/test-import-expression.js
+++ b/test/realm/test-import-expression.js
@@ -46,6 +46,8 @@ const safe2 = `const a = notimport('evil')`;
 
 const safe3 = `const a = importnot('evil')`;
 
+const safe4 = `/** @param {import('evil').Something}} ... */`;
+
 const obvious = `const a = import('evil')`;
 
 const whitespace = `const a = import ('evil')`;
@@ -54,6 +56,9 @@ const comment = `const a = import/*hah*/('evil')`;
 
 const doubleSlashComment = `const a = import // hah
 ('evil')`;
+
+const evilAfterSafe = `/** @param {import('evil').Something}} ... */
+import('otherevil')`;
 
 // We break up the following literal strings so that an apparent html
 // comment does not appear in this file. Thus, we avoid rejection by
@@ -81,9 +86,15 @@ test('no-import-expression regexp', t => {
   t.equal(rejectDangerousSources(safe), undefined, 'safe');
   t.equal(rejectDangerousSources(safe2), undefined, 'safe2');
   t.equal(rejectDangerousSources(safe3), undefined, 'safe3');
+  t.equal(rejectDangerousSources(safe4), undefined, 'safe4');
   t.throws(() => rejectDangerousSources(obvious), SyntaxError, 'obvious');
   t.throws(() => rejectDangerousSources(whitespace), SyntaxError, 'whitespace');
   t.throws(() => rejectDangerousSources(comment), SyntaxError, 'comment');
+  t.throws(
+    () => rejectDangerousSources(evilAfterSafe),
+    SyntaxError,
+    'evilAfterSafe'
+  );
   t.throws(
     () => rejectDangerousSources(doubleSlashComment),
     SyntaxError,
@@ -127,9 +138,15 @@ test('reject import expressions in evaluate', t => {
   t.equal(r.evaluate(wrap(safe)), undefined, 'safe');
   t.equal(r.evaluate(wrap(safe2)), undefined, 'safe2');
   t.equal(r.evaluate(wrap(safe3)), undefined, 'safe3');
+  t.equal(r.evaluate(wrap(safe4)), undefined, 'safe4');
   t.throws(() => r.evaluate(wrap(obvious)), SyntaxError, 'obvious');
   t.throws(() => r.evaluate(wrap(whitespace)), SyntaxError, 'whitespace');
   t.throws(() => r.evaluate(wrap(comment)), SyntaxError, 'comment');
+  t.throws(
+    () => rejectDangerousSources(evilAfterSafe),
+    SyntaxError,
+    'evilAfterSafe'
+  );
   t.throws(
     () => r.evaluate(wrap(doubleSlashComment)),
     SyntaxError,
@@ -160,9 +177,15 @@ test('reject import expressions in Function', t => {
   r.evaluate(wrap(safe));
   r.evaluate(wrap(safe2));
   r.evaluate(wrap(safe3));
+  r.evaluate(wrap(safe4));
   t.throws(() => r.evaluate(wrap(obvious)), SyntaxError, 'obvious');
   t.throws(() => r.evaluate(wrap(whitespace)), SyntaxError, 'whitespace');
   t.throws(() => r.evaluate(wrap(comment)), SyntaxError, 'comment');
+  t.throws(
+    () => r.evaluate(wrap(evilAfterSafe)),
+    SyntaxError,
+    'evilAfterSafe'
+  );
   t.throws(
     () => r.evaluate(wrap(doubleSlashComment)),
     SyntaxError,


### PR DESCRIPTION
This change allows import expressions to be used within JSDoc blocks.

It takes advantage of the fact that `@param {import(...)}` is not valid Javascript syntax, not even after decorators are landed, so it cannot be an evaluable import expression.

https://github.com/Agoric/SES-shim/issues/261
