### PR TITLE
Also allow `typeof` JSDoc imports.

### DIFF
--- a/src/sourceParser.js
+++ b/src/sourceParser.js
@@ -54,14 +54,17 @@ const importPattern = /\bimport\s*(?:\(|\/[/*])/;
 
 // Still allow JSDocs that use `import()` such as:
 // * @param {import('./foo.js').MyType}
+// * @param {typeof import('./foo.js').Obj}
 //
 // Note that this is not valid syntax outside of a comment
 // (import expressions cannot be the start of an object literal,
 // nor can decorators adorn blocks).
 //
-// Also note that the dollar at the end matches only the end of string,
+// Also note that the dollar at the end matches where the import begins
 // since the 's' modifier is given.
-const allowedImportPrefix = /@[a-z]+ +\{$/s;
+//
+// BE CAREFUL not to use `\s`, as that will match newlines.
+const allowedImportPrefix = /@[a-z]+ +\{(typeof +)?$/s;
 
 function rejectImportExpressions(s) {
   let index = 0;

--- a/src/sourceParser.js
+++ b/src/sourceParser.js
@@ -64,7 +64,7 @@ const importPattern = /\bimport\s*(?:\(|\/[/*])/;
 // since the 's' modifier is given.
 //
 // BE CAREFUL not to use `\s`, as that will match newlines.
-const allowedImportPrefix = /@[a-z]+ +\{(typeof +)?$/s;
+const allowedImportPrefix = /@[a-z]+ +\{((type|key)of +)?$/s;
 
 function rejectImportExpressions(s) {
   let index = 0;

--- a/test/realm/test-import-expression.js
+++ b/test/realm/test-import-expression.js
@@ -46,7 +46,9 @@ const safe2 = `const a = notimport('evil')`;
 
 const safe3 = `const a = importnot('evil')`;
 
-const safe4 = `/** @param {import('evil').Something}} ... */`;
+const safe4 = `/** @param {import('evil').Something} ... */`;
+
+const safe5 = `/** @param {typeof import('evil').Other} ... */`;
 
 const obvious = `const a = import('evil')`;
 
@@ -57,7 +59,7 @@ const comment = `const a = import/*hah*/('evil')`;
 const doubleSlashComment = `const a = import // hah
 ('evil')`;
 
-const evilAfterSafe = `/** @param {import('evil').Something}} ... */
+const evilAfterSafe = `/** @param {import('evil').Something} ... */
 import('otherevil')`;
 
 // We break up the following literal strings so that an apparent html
@@ -87,6 +89,7 @@ test('no-import-expression regexp', t => {
   t.equal(rejectDangerousSources(safe2), undefined, 'safe2');
   t.equal(rejectDangerousSources(safe3), undefined, 'safe3');
   t.equal(rejectDangerousSources(safe4), undefined, 'safe4');
+  t.equal(rejectDangerousSources(safe5), undefined, 'safe5');
   t.throws(() => rejectDangerousSources(obvious), SyntaxError, 'obvious');
   t.throws(() => rejectDangerousSources(whitespace), SyntaxError, 'whitespace');
   t.throws(() => rejectDangerousSources(comment), SyntaxError, 'comment');
@@ -139,6 +142,7 @@ test('reject import expressions in evaluate', t => {
   t.equal(r.evaluate(wrap(safe2)), undefined, 'safe2');
   t.equal(r.evaluate(wrap(safe3)), undefined, 'safe3');
   t.equal(r.evaluate(wrap(safe4)), undefined, 'safe4');
+  t.equal(r.evaluate(wrap(safe5)), undefined, 'safe5');
   t.throws(() => r.evaluate(wrap(obvious)), SyntaxError, 'obvious');
   t.throws(() => r.evaluate(wrap(whitespace)), SyntaxError, 'whitespace');
   t.throws(() => r.evaluate(wrap(comment)), SyntaxError, 'comment');
@@ -178,6 +182,7 @@ test('reject import expressions in Function', t => {
   r.evaluate(wrap(safe2));
   r.evaluate(wrap(safe3));
   r.evaluate(wrap(safe4));
+  r.evaluate(wrap(safe5));
   t.throws(() => r.evaluate(wrap(obvious)), SyntaxError, 'obvious');
   t.throws(() => r.evaluate(wrap(whitespace)), SyntaxError, 'whitespace');
   t.throws(() => r.evaluate(wrap(comment)), SyntaxError, 'comment');

--- a/test/realm/test-import-expression.js
+++ b/test/realm/test-import-expression.js
@@ -50,6 +50,8 @@ const safe4 = `/** @param {import('evil').Something} ... */`;
 
 const safe5 = `/** @param {typeof import('evil').Other} ... */`;
 
+const safe6 = `/** @param {keyof import('evil').Other} ... */`;
+
 const obvious = `const a = import('evil')`;
 
 const whitespace = `const a = import ('evil')`;
@@ -90,6 +92,7 @@ test('no-import-expression regexp', t => {
   t.equal(rejectDangerousSources(safe3), undefined, 'safe3');
   t.equal(rejectDangerousSources(safe4), undefined, 'safe4');
   t.equal(rejectDangerousSources(safe5), undefined, 'safe5');
+  t.equal(rejectDangerousSources(safe6), undefined, 'safe6');
   t.throws(() => rejectDangerousSources(obvious), SyntaxError, 'obvious');
   t.throws(() => rejectDangerousSources(whitespace), SyntaxError, 'whitespace');
   t.throws(() => rejectDangerousSources(comment), SyntaxError, 'comment');
@@ -143,6 +146,7 @@ test('reject import expressions in evaluate', t => {
   t.equal(r.evaluate(wrap(safe3)), undefined, 'safe3');
   t.equal(r.evaluate(wrap(safe4)), undefined, 'safe4');
   t.equal(r.evaluate(wrap(safe5)), undefined, 'safe5');
+  t.equal(r.evaluate(wrap(safe6)), undefined, 'safe6');
   t.throws(() => r.evaluate(wrap(obvious)), SyntaxError, 'obvious');
   t.throws(() => r.evaluate(wrap(whitespace)), SyntaxError, 'whitespace');
   t.throws(() => r.evaluate(wrap(comment)), SyntaxError, 'comment');
@@ -183,6 +187,7 @@ test('reject import expressions in Function', t => {
   r.evaluate(wrap(safe3));
   r.evaluate(wrap(safe4));
   r.evaluate(wrap(safe5));
+  r.evaluate(wrap(safe6));
   t.throws(() => r.evaluate(wrap(obvious)), SyntaxError, 'obvious');
   t.throws(() => r.evaluate(wrap(whitespace)), SyntaxError, 'whitespace');
   t.throws(() => r.evaluate(wrap(comment)), SyntaxError, 'comment');


### PR DESCRIPTION
Refs #124

This adds more support for JSDoc imports, namely:
```js
/**
 * @param {typeof import('./foo.js').Obj}
 * @param {keyof typeof import('./foo.js').Obj}
 */
```