### PR TITLE
Avoid polluting host Function prototypes

### DIFF
--- a/src/unsafeRec.js
+++ b/src/unsafeRec.js
@@ -127,6 +127,5 @@ export function createCurrentUnsafeRec() {
   const unsafeEval = eval;
   const unsafeGlobal = unsafeEval(unsafeGlobalSrc);
   repairAccessors();
-  repairFunctions();
   return createUnsafeRec(unsafeGlobal);
 }


### PR DESCRIPTION
Fixes <https://github.com/Agoric/realms-shim/issues/52>

---

`createCurrentUnsafeRec()` is only called once from `realm.js` to create a `unsafeRec` for the host’s primal Realm:
<https://github.com/Agoric/realms-shim/blob/067bdd9404013e95b9603379cb1fb597f0bfdc50/src/realm.js#L169>