### PR TITLE
fix `eval(<non‑string>)` and `eval.length`

### DIFF
--- a/src/safeEval.js
+++ b/src/safeEval.js
@@ -5,15 +5,15 @@ function buildSafeEval(unsafeRec, safeEvalOperation) {
 
   const { defineProperties } = Object;
 
-  // We use the the concise method syntax to create an eval without a
-  // [[Construct]] behavior (such that the invocation "new eval()" throws
-  // TypeError: eval is not a constructor"), but which still accepts a
-  // 'this' binding.
-  const safeEval = {
-    eval() {
-      return callAndWrapError(safeEvalOperation, arguments);
-    }
-  }.eval;
+  // We use the the arrow function syntax to create an eval without
+  // a [[Construct]] internal method (such that the invocation "new eval()"
+  // throws "TypeError: eval is not a constructor"), since the 'this' binding
+  // is ignored. This also prevents rejection by the overly eager
+  // rejectDangerousSources.
+  const safeEval = x =>
+    // https://tc39.es/ecma262/#sec-performeval
+    // 2. If Type(x) is not String, return x.
+    typeof x !== 'string' ? x : callAndWrapError(safeEvalOperation, [x]);
 
   // safeEval's prototype RootRealm's value and instanceof Function
   // is true inside the realm. It doesn't point at the primal realm
@@ -21,6 +21,9 @@ function buildSafeEval(unsafeRec, safeEvalOperation) {
   // intrinsics.
 
   defineProperties(safeEval, {
+    // `eval.length` is already initialized correctly.
+    // Ensure that `eval.name` is also correct:
+    name: { value: 'eval' },
     toString: {
       // We break up the following literal string so that an
       // apparent direct eval syntax does not appear in this

--- a/src/safeEval.js
+++ b/src/safeEval.js
@@ -23,7 +23,12 @@ function buildSafeEval(unsafeRec, safeEvalOperation) {
   defineProperties(safeEval, {
     // `eval.length` is already initialized correctly.
     // Ensure that `eval.name` is also correct:
-    name: { value: 'eval' },
+    name: {
+      value: 'eval',
+      writable: false,
+      enumerable: false,
+      configurable: true
+    },
     toString: {
       // We break up the following literal string so that an
       // apparent direct eval syntax does not appear in this

--- a/test/realm/function-eval.js
+++ b/test/realm/function-eval.js
@@ -166,6 +166,26 @@ test('degenerate-pattern-match-argument', t => {
   t.end();
 });
 
+test('eval-own-properties', t => {
+  const r = Realm.makeRootRealm();
+
+  const evalFunc = r.global.eval;
+  t.equal(evalFunc.name, 'eval', 'eval.name === "eval"');
+  t.equal(evalFunc.length, 1, 'eval.length === 1');
+  t.equal(
+    Object.getOwnPropertyDescriptor(evalFunc, 'prototype'),
+    undefined,
+    'eval.prototype === undefined'
+  );
+  t.equal(
+    evalFunc.toString(),
+    'function eval() { [shim code] }',
+    'eval.toString()'
+  );
+
+  t.end();
+});
+
 test('frozen-eval', t => {
   const r = Realm.makeRootRealm();
 
@@ -174,7 +194,15 @@ test('frozen-eval', t => {
   desc.configurable = false;
   Object.defineProperty(r.global, 'eval', desc);
 
-  t.equal(r.evaluate('(0,eval)(1)'), 1);
+  t.equal(r.evaluate('(0,eval)("1")'), 1);
+  t.equal(
+    r.evaluate(`\
+      const sym = Symbol("foo");
+      (0,eval)(sym) === sym;
+    `),
+    true,
+    'eval(<non-string>) returns <non-string>'
+  );
 
   t.end();
 });


### PR DESCRIPTION
See <https://tc39.es/ecma262/#sec-performeval>:

> 2. If [Type]\(<var>x</var>\) is not String, return <var>x</var>.

[Type]: https://tc39.es/ecma262/#sec-ecmascript-data-types-and-values