### PR TITLE
chore: mark package as deprecated and insecure

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@
 [![dev dependency status][dev-deps-svg]][dev-deps-url]
 [![License][license-image]][license-url]
 
-This repository contains a shim implementation of an outdated [Realm API Proposal](https://github.com/tc39/proposal-realms/tree/ff7583930ed67dda603b59e343b3ed85ac741d35#ecmascript-spec-proposal-for-realms-api). 
+This repository contains a legacy shim implementation of an outdated [Realm API Proposal](https://github.com/tc39/proposal-realms/tree/ff7583930ed67dda603b59e343b3ed85ac741d35#ecmascript-spec-proposal-for-realms-api). 
 
 The Realms proposal has been superceded by the [ShadowRealm Proposal](https://github.com/tc39/proposal-shadowrealm/). This shim does not implement ShadowRealm, which (as of this writing) is a proposal at Stage 3 of the TC39 standardization process, so common JS engines should have support soon.
 
-We do not recommend the use of this shim or the original Realms approach. The main danger is that intrinsics are not automatically frozen, so when two mutually-suspicious Realms are communicating, both must be extremely careful to prevent any object leakage, otherwise one Realm can pollute the globals or intrinsics of the other. This can be prevented with a "Membrane Pattern", but the shim doesn't provide one, and the details are tricky to get right.
+We do not recommend the use of this shim or the original Realms approach. While the Realm API allows the user to create a new set of independent built-ins (intrinsics), this cannot be used for isolation or security properties without either freezing those intrinsics or hiding them behind a Membrane. The shim provides no mechanism to do either, and both are non-trivial to implement. Without those, when two mutually-suspicious Realms are communicating, both must be extremely careful to prevent any object leakage, otherwise one Realm can pollute the globals or intrinsics of the other.
 
 ShadowRealms defines a "callable boundary" which prevents objects from passing through, mitigating this danger.
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,21 @@
-# Realm Shim
+# Realms Shim : OBSOLETE, INSECURE, NOT RECOMMENDED FOR USE
+
 [![Build Status][circleci-svg]][circleci-url]
 [![Coverage Status][coveralls-svg]][coveralls-url]
 [![dependency status][deps-svg]][deps-url]
 [![dev dependency status][dev-deps-svg]][dev-deps-url]
 [![License][license-image]][license-url]
 
+This repository contains a shim implementation of the [Realm API Proposal](https://github.com/tc39/proposal-realms/#ecmascript-spec-proposal-for-realms-api). 
 
-This folder contains a shim implementation of the [Realm API Proposal](https://github.com/tc39/proposal-realms/#ecmascript-spec-proposal-for-realms-api). 
+The Realms proposal has been superceded by the [ShadowRealms Proposal](https://github.com/tc39/proposal-shadowrealm/). This shim does not implement ShadowRealms, but (as of this writing) the proposal is at Stage 3 of the TC39 standardization process, so common JS engines should have support soon.
+
+We do not recommend the use of this shim or the original Realms approach. The main danger is that intrinsics are not automatically frozen, so when two mutually-suspicious Realms are communicating, both must be extremely careful to prevent any object leakage, otherwise one Realm can pollute the globals or intrinsics of the other. This can be prevented with a "Membrane Pattern", but the shim doesn't provide one, and the details are tricky to get right.
+
+ShadowRealms defines a "callable boundary" which prevents objects from passing through, mitigating this danger.
+
+In general, we recommend the use of alternate isolation tools like [Endo](https://github.com/endojs/endo/) and the related/embedded SES/HardenedJS environment. This provides `lockdown()` to tame the environment at startup, and the `Compartment` constructor to create evaluation compartments with independent (and potentially frozen) globals. In our experience with the [Agoric SDK](https://github.com/Agoric/agoric-sdk), we find Endo to be much safer and easier to use securely.
+
 
 ## Limitations
 
@@ -102,17 +111,6 @@ const r = new Realm({ intrinsics: 'inherit' }); // realm compartment
 r.global === this; // false
 r.global.JSON === JSON; // true
 ```
-
-
-## Bug Disclosure
-
-Please help us practice coordinated security bug disclosure, by using the
-instructions in
-[SECURITY.md](https://github.com/Agoric/realms-shim/blob/master/SECURITY.md)
-to report security-sensitive bugs privately.
-
-For non-security bugs, please use the [regular Issues
-page](https://github.com/Agoric/realms-shim/issues).
 
 
 [circleci-svg]: https://circleci.com/gh/Agoric/realms-shim.svg?style=svg

--- a/README.md
+++ b/README.md
@@ -1,9 +1,5 @@
 # Realms Shim : OBSOLETE, INSECURE, NOT RECOMMENDED FOR USE
 
-[![Build Status][circleci-svg]][circleci-url]
-[![Coverage Status][coveralls-svg]][coveralls-url]
-[![dependency status][deps-svg]][deps-url]
-[![dev dependency status][dev-deps-svg]][dev-deps-url]
 [![License][license-image]][license-url]
 
 This repository contains a legacy shim implementation of an outdated [Realm API Proposal](https://github.com/tc39/proposal-realms/tree/ff7583930ed67dda603b59e343b3ed85ac741d35#ecmascript-spec-proposal-for-realms-api). 
@@ -113,13 +109,5 @@ r.global.JSON === JSON; // true
 ```
 
 
-[circleci-svg]: https://circleci.com/gh/Agoric/realms-shim.svg?style=svg
-[circleci-url]: https://circleci.com/gh/Agoric/realms-shim
-[coveralls-svg]: https://coveralls.io/repos/github/Agoric/realms-shim/badge.svg
-[coveralls-url]: https://coveralls.io/github/Agoric/realms-shim
-[deps-svg]: https://david-dm.org/Agoric/realms-shim.svg
-[deps-url]: https://david-dm.org/Agoric/realms-shim
-[dev-deps-svg]: https://david-dm.org/Agoric/realms-shim/dev-status.svg
-[dev-deps-url]: https://david-dm.org/Agoric/realms-shim?type=dev
 [license-image]: https://img.shields.io/badge/License-Apache%202.0-blue.svg
 [license-url]: LICENSE

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 This repository contains a shim implementation of an outdated [Realm API Proposal](https://github.com/tc39/proposal-realms/tree/ff7583930ed67dda603b59e343b3ed85ac741d35#ecmascript-spec-proposal-for-realms-api). 
 
-The Realms proposal has been superceded by the [ShadowRealms Proposal](https://github.com/tc39/proposal-shadowrealm/). This shim does not implement ShadowRealms, but (as of this writing) the proposal is at Stage 3 of the TC39 standardization process, so common JS engines should have support soon.
+The Realms proposal has been superceded by the [ShadowRealm Proposal](https://github.com/tc39/proposal-shadowrealm/). This shim does not implement ShadowRealm, which (as of this writing) is a proposal at Stage 3 of the TC39 standardization process, so common JS engines should have support soon.
 
 We do not recommend the use of this shim or the original Realms approach. The main danger is that intrinsics are not automatically frozen, so when two mutually-suspicious Realms are communicating, both must be extremely careful to prevent any object leakage, otherwise one Realm can pollute the globals or intrinsics of the other. This can be prevented with a "Membrane Pattern", but the shim doesn't provide one, and the details are tricky to get right.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![dev dependency status][dev-deps-svg]][dev-deps-url]
 [![License][license-image]][license-url]
 
-This repository contains a shim implementation of the [Realm API Proposal](https://github.com/tc39/proposal-realms/#ecmascript-spec-proposal-for-realms-api). 
+This repository contains a shim implementation of an outdated [Realm API Proposal](https://github.com/tc39/proposal-realms/tree/ff7583930ed67dda603b59e343b3ed85ac741d35#ecmascript-spec-proposal-for-realms-api). 
 
 The Realms proposal has been superceded by the [ShadowRealms Proposal](https://github.com/tc39/proposal-shadowrealm/). This shim does not implement ShadowRealms, but (as of this writing) the proposal is at Stage 3 of the TC39 standardization process, so common JS engines should have support soon.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,27 +1,6 @@
 # Security Policy
 
-## Supported Versions
-
-The realms-shim is still undergoing development and security review, and all
-users are encouraged to use the latest version available. Security fixes will
-be made for the most recent branch only.
-
-| Version | Supported          |
-| ------- | ------------------ |
-| 1.2.x   | :white_check_mark: |
-| 1.1.x   | :x:                |
-| 0.x.x   | :x:                |
-
-## Reporting a Vulnerability
-
-Please help us practice coordinated security bug disclosure. If you find a
-security-sensitive bug that should not be revealed publically until a fix is
-available, please send email to `security` at (@) `agoric.com`. To encrypt,
-please use my (@warner) personal GPG key [A476E2E6 11880C98 5B3C3A39 0386E81B
-11CAA07A](http://www.lothar.com/warner-gpg.html) . Keybase users can also
-send messages to `@agoric_security`, or share code and other log files via
-the Keybase encrypted file system
-(`/keybase/private/agoric_security,$YOURNAME`).
-
-We will create a GitHub security advisory promptly. Let us know your GitHub
-username and we'll add you to the collaborator list for further discussion.
+The realms-shim was used to demonstrate the Realms Proposal, but has been
+deprecated. It is known to have significant security problems and is not
+recommended for use. We are not treating security-sensitive bugs differently
+than normal issues.


### PR DESCRIPTION
As discussed, this updates the README and SECURITY.md to reflect the deprecation of this package.
